### PR TITLE
#57 [feat] request error 처리 + 404 에러 핸들링

### DIFF
--- a/src/main/java/com/asap/server/common/advice/ControllerExceptionAdvice.java
+++ b/src/main/java/com/asap/server/common/advice/ControllerExceptionAdvice.java
@@ -15,6 +15,8 @@ import javax.validation.ConstraintViolationException;
 import javax.validation.ValidationException;
 
 import com.asap.server.exception.Error;
+import org.springframework.web.servlet.NoHandlerFoundException;
+
 import java.io.IOException;
 
 @RestControllerAdvice
@@ -36,6 +38,13 @@ public class ControllerExceptionAdvice {
     protected ErrorResponse handleMethodArgumentNotValidException(final MethodArgumentNotValidException e) {
         return ErrorResponse.error(Error.VALIDATION_REQUEST_MISSING_EXCEPTION);
     }
+
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ExceptionHandler(NoHandlerFoundException.class)
+    public ErrorResponse handleNotFoundException(NoHandlerFoundException exception) {
+        return ErrorResponse.error(Error.URI_NOT_FOUND_EXCEPTION);
+    }
+
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(HttpMessageNotReadableException.class)
     protected ErrorResponse handleJsonParseException(final HttpMessageNotReadableException e){

--- a/src/main/java/com/asap/server/common/advice/ControllerExceptionAdvice.java
+++ b/src/main/java/com/asap/server/common/advice/ControllerExceptionAdvice.java
@@ -3,9 +3,10 @@ package com.asap.server.common.advice;
 import com.asap.server.common.dto.ErrorResponse;
 import com.asap.server.common.utils.SlackUtil;
 import com.asap.server.exception.model.AsapException;
-import com.asap.server.exception.model.BadRequestException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -26,8 +27,19 @@ public class ControllerExceptionAdvice {
      */
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(ValidationException.class)
-    protected ErrorResponse handleMethodArgumentNotValidException(final ValidationException e) {
+    protected ErrorResponse handleValidException(final ValidationException e) {
         return ErrorResponse.error(Error.VALIDATION_REQUEST_MISSING_EXCEPTION);
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ErrorResponse handleMethodArgumentNotValidException(final MethodArgumentNotValidException e) {
+        return ErrorResponse.error(Error.VALIDATION_REQUEST_MISSING_EXCEPTION);
+    }
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    protected ErrorResponse handleJsonParseException(final HttpMessageNotReadableException e){
+        return ErrorResponse.error(Error.INVALID_JSON_INPUT_EXCEPTION);
     }
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)

--- a/src/main/java/com/asap/server/config/WebConfig.java
+++ b/src/main/java/com/asap/server/config/WebConfig.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @RequiredArgsConstructor
@@ -16,6 +17,12 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 public class WebConfig implements WebMvcConfigurer {
     private final MeetingIdResolver meetingIdResolver;
     private final UserIdResolver userIdResolver;
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/files/**")
+                .addResourceLocations("classpath:/static/");
+    }
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {

--- a/src/main/java/com/asap/server/controller/dto/request/AvailableTimeRequestDto.java
+++ b/src/main/java/com/asap/server/controller/dto/request/AvailableTimeRequestDto.java
@@ -13,10 +13,10 @@ import java.util.List;
 @Schema(description = "사용자 가능 시간 DTO")
 public class AvailableTimeRequestDto {
     @NotBlank
-    @Size(max = 8 , message = "방장 이름의 최대 입력 길이(8자)를 초과했습니다.")
+    @Size(max = 8 , message = "이름의 최대 입력 길이(8자)를 초과했습니다.")
     @Schema(description = "사용자 이름",example = "김아삽")
     private String name;
 
-    @Schema(description = "가능 일자", example = "[\"2024/09/12/TUE\", \"2024/09/13/WED\"]")
+    @Schema(description = "가능 일자")
     private List<UserMeetingTimeSaveRequestDto> availableTimes;
 }

--- a/src/main/java/com/asap/server/controller/dto/request/MeetingSaveRequestDto.java
+++ b/src/main/java/com/asap/server/controller/dto/request/MeetingSaveRequestDto.java
@@ -2,6 +2,7 @@ package com.asap.server.controller.dto.request;
 
 import com.asap.server.domain.enums.Duration;
 import com.asap.server.domain.enums.Place;
+
 import java.util.List;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
@@ -19,12 +20,12 @@ import lombok.NoArgsConstructor;
 public class MeetingSaveRequestDto {
 
     @NotBlank(message = "회의 제목이 입력되지 않았습니다.")
-    @Size(max = 15 , message = "제목의 최대 입력 길이(15자)를 초과했습니다.")
+    @Size(max = 15, message = "제목의 최대 입력 길이(15자)를 초과했습니다.")
     @Schema(description = "회의 주제")
     private String title;
 
-    @Schema(description = "회의 가능 날짜", example = "2023/07/09/MON")
-    private List< @Pattern(regexp = "\\d\\d\\d\\d/\\d\\d/\\d\\d/[a-zA-Z][a-zA-Z][a-zA-Z]", message = "회의 가능 날짜 형식은 YYYY/mm/dd/ddd 입니다.") String> availableDates;
+    @Schema(description = "회의 가능 날짜", example = "[\"2023/07/09/MON\"]")
+    private List<@Pattern(regexp = "\\d\\d\\d\\d/\\d\\d/\\d\\d/[a-zA-Z][a-zA-Z][a-zA-Z]", message = "회의 가능 날짜 형식은 YYYY/mm/dd/ddd 입니다.") String> availableDates;
 
     @Schema(description = "회의 선호 시간")
     private List<PreferTimeSaveRequestDto> preferTimes;
@@ -42,7 +43,7 @@ public class MeetingSaveRequestDto {
 
     @Schema(description = "회의 방장 이름", example = "김아삽")
     @NotBlank(message = "방장의 이름이 입력되지 않았습니다.")
-    @Size(max = 8 , message = "방장 이름의 최대 입력 길이(8자)를 초과했습니다.")
+    @Size(max = 8, message = "방장 이름의 최대 입력 길이(8자)를 초과했습니다.")
     private String name;
 
     @Schema(description = "회의 비밀번호", example = "0808")

--- a/src/main/java/com/asap/server/controller/dto/request/PreferTimeSaveRequestDto.java
+++ b/src/main/java/com/asap/server/controller/dto/request/PreferTimeSaveRequestDto.java
@@ -6,17 +6,14 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.validation.constraints.Pattern;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PreferTimeSaveRequestDto {
 
     @Schema(description = "선호 시간(시작)", example = "09:00")
-    @Pattern(regexp = "\\d\\d:\\d\\d", message = "시간은 hh:mm 형식이어야 합니다.")
     private TimeSlot startTime;
 
     @Schema(description = "선호 시간(끝)", example = "11:00")
-    @Pattern(regexp = "\\d\\d:\\d\\d", message = "시간은 hh:mm 형식이어야 합니다.")
     private TimeSlot endTime;
 }

--- a/src/main/java/com/asap/server/controller/dto/request/UserMeetingTimeSaveRequestDto.java
+++ b/src/main/java/com/asap/server/controller/dto/request/UserMeetingTimeSaveRequestDto.java
@@ -12,6 +12,7 @@ import javax.validation.constraints.Pattern;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Schema(description = "회의 가능 시간 DTO")
 public class UserMeetingTimeSaveRequestDto {
 
     @NotBlank
@@ -19,12 +20,12 @@ public class UserMeetingTimeSaveRequestDto {
     private String id;
 
     @NotBlank
-    @Schema(description = "회의 가능 시간 (월)", example = "1")
+    @Schema(description = "회의 가능 시간 (월)", example = "01")
     @Pattern(regexp = "\\d{2}", message = "날짜 형식이 맞지 않습니다.")
     private String month;
 
     @NotBlank
-    @Schema(description = "회의 가능 시간 (일)", example = "1")
+    @Schema(description = "회의 가능 시간 (일)", example = "01")
     @Pattern(regexp = "\\d{2}", message = "날짜 형식이 맞지 않습니다.")
     private String day;
 
@@ -33,14 +34,10 @@ public class UserMeetingTimeSaveRequestDto {
     @Pattern(regexp = "[\\uAC00-\\uD7A3]", message = "날짜 형식이 맞지 않습니다.")
     private String dayOfWeek;
 
-    @NotNull
     @Schema(description = "회의 가능 시간 (시작 시간)", example = "09:00")
-    @Pattern(regexp = "\\d\\d:\\d\\d", message = "시간은 hh:mm 형식이어야 합니다.")
     private TimeSlot startTime;
 
-    @NotNull
     @Schema(description = "회의 가능 시간 (끝 시간)", example = "11:00")
-    @Pattern(regexp = "\\d\\d:\\d\\d", message = "시간은 hh:mm 형식이어야 합니다.")
     private TimeSlot endTime;
 
     @NotNull

--- a/src/main/java/com/asap/server/domain/enums/Duration.java
+++ b/src/main/java/com/asap/server/domain/enums/Duration.java
@@ -1,8 +1,13 @@
 package com.asap.server.domain.enums;
 
+import com.asap.server.exception.Error;
+import com.asap.server.exception.model.BadRequestException;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+
+import java.util.stream.Stream;
 
 @AllArgsConstructor
 public enum Duration {
@@ -16,4 +21,12 @@ public enum Duration {
     @Getter
     @JsonValue
     private String duration;
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static Duration findByTime(String duration) {
+        return Stream.of(Duration.values())
+                .filter(c -> c.getDuration().equals(duration))
+                .findFirst()
+                .orElseThrow(() -> new BadRequestException(Error.INVALID_JSON_INPUT_EXCEPTION));
+    }
 }

--- a/src/main/java/com/asap/server/domain/enums/Place.java
+++ b/src/main/java/com/asap/server/domain/enums/Place.java
@@ -1,8 +1,13 @@
 package com.asap.server.domain.enums;
 
+import com.asap.server.exception.Error;
+import com.asap.server.exception.model.BadRequestException;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+
+import java.util.stream.Stream;
 
 @AllArgsConstructor
 public enum Place {
@@ -13,4 +18,12 @@ public enum Place {
     @Getter
     @JsonValue
     private String place;
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static Place findByTime(String place) {
+        return Stream.of(Place.values())
+                .filter(c -> c.getPlace().equals(place))
+                .findFirst()
+                .orElseThrow(() -> new BadRequestException(Error.INVALID_JSON_INPUT_EXCEPTION));
+    }
 }

--- a/src/main/java/com/asap/server/domain/enums/TimeSlot.java
+++ b/src/main/java/com/asap/server/domain/enums/TimeSlot.java
@@ -67,4 +67,12 @@ public enum TimeSlot {
         }
         return result;
     }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static TimeSlot findByTime(String timeSlot) {
+        return Stream.of(TimeSlot.values())
+                .filter(c -> c.getTime().equals(timeSlot))
+                .findFirst()
+                .orElseThrow(() -> new BadRequestException(Error.INVALID_JSON_INPUT_EXCEPTION));
+    }
 }

--- a/src/main/java/com/asap/server/exception/Error.java
+++ b/src/main/java/com/asap/server/exception/Error.java
@@ -31,6 +31,7 @@ public enum Error {
     /**
      * 404 NOT FOUND
      */
+    URI_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "지원하지 않는 URL 입니다."),
     USER_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 유저는 존재하지 않습니다."),
     MEETING_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 회의는 존재하지 않습니다."),
     MEETING_TIME_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 유저의 회의 시간이 존재하지 않습니다."),

--- a/src/main/java/com/asap/server/exception/Error.java
+++ b/src/main/java/com/asap/server/exception/Error.java
@@ -16,7 +16,7 @@ public enum Error {
     VALIDATION_REQUEST_MISSING_EXCEPTION(HttpStatus.BAD_REQUEST, "요청값이 유효하지 않습니다."),
     DUPLICATED_TIME_EXCEPTION(HttpStatus.BAD_REQUEST,"중복 입력된 시간이 있습니다."),
     INVALID_TIME_RANGE(HttpStatus.BAD_REQUEST,"입력한 시간이 회의 가능 일시에 해당하지 않습니다."),
-    INVALID_TIME_SLOT_EXCEPTION(HttpStatus.BAD_REQUEST, "시간 형식이 맞지 않습니다."),
+    INVALID_JSON_INPUT_EXCEPTION(HttpStatus.BAD_REQUEST, "입력 형식이 맞지 않습니다."),
     /**
      * 401 UNAUTHORIZED
      **/


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #57 

## Key Changes 🔑
1. request error 처리 + 404 에러 핸들링

## To Reviewers 📢
- jsoncreator 어노테이션으로 enum 유효성 검사하는 로직으로 만약 enum에 존재하지 않는 값을 받으면 400에러 던져주었습니다.