### PR TITLE
#111 [fix] 큐카드 API 수정

### DIFF
--- a/src/main/java/com/asap/server/common/utils/DayOfWeekConverter.java
+++ b/src/main/java/com/asap/server/common/utils/DayOfWeekConverter.java
@@ -1,0 +1,35 @@
+package com.asap.server.common.utils;
+
+import com.asap.server.exception.model.BadRequestException;
+import java.time.DayOfWeek;
+
+public class DayOfWeekConverter {
+    public static String convertDayOfWeekEnToKo(DayOfWeek dayOfWeekEn) {
+        String dayOfWeekKr;
+        switch (dayOfWeekEn) {
+            case MONDAY:
+                dayOfWeekKr = "월";
+                break;
+            case TUESDAY:
+                dayOfWeekKr = "화";
+                break;
+            case WEDNESDAY:
+                dayOfWeekKr = "수";
+                break;
+            case THURSDAY:
+                dayOfWeekKr = "목";
+                break;
+            case FRIDAY:
+                dayOfWeekKr = "금";
+                break;
+            case SATURDAY:
+                dayOfWeekKr = "토";
+                break;
+            case SUNDAY:
+                dayOfWeekKr = "일";
+                break;
+            default: throw new BadRequestException(String.format("%s 값은 유효하지 않은 입력 값입니다.", dayOfWeekEn));
+        }
+        return dayOfWeekKr;
+    }
+}

--- a/src/main/java/com/asap/server/controller/MeetingController.java
+++ b/src/main/java/com/asap/server/controller/MeetingController.java
@@ -86,9 +86,7 @@ public class MeetingController {
     @Operation(summary = "[큐 카드] 큐 카드 조회 API")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "유저 정보 조회 성공"),
-            @ApiResponse(responseCode = "400", description = "해당 회의는 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "401", description = "해당 유저는 해당 방의 방장이 아닙니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "404", description = "해당 유저는 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "해당 회의는 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @GetMapping("/{meetingId}/card")

--- a/src/main/java/com/asap/server/controller/dto/response/FixedMeetingResponseDto.java
+++ b/src/main/java/com/asap/server/controller/dto/response/FixedMeetingResponseDto.java
@@ -1,5 +1,6 @@
 package com.asap.server.controller.dto.response;
 
+import com.asap.server.common.utils.DayOfWeekConverter;
 import com.asap.server.domain.ConfirmedDateTime;
 import com.asap.server.domain.Meeting;
 import com.asap.server.domain.User;
@@ -35,7 +36,7 @@ public class FixedMeetingResponseDto {
         ConfirmedDateTime confirmedDateTime = meeting.getConfirmedDateTime();
         String month = String.valueOf(confirmedDateTime.getStartDateTime().getMonthValue());
         String day = String.valueOf(confirmedDateTime.getStartDateTime().getDayOfMonth());
-        String dayOfWeek = confirmedDateTime.getStartDateTime().getDayOfWeek().toString();
+        String dayOfWeek = DayOfWeekConverter.convertDayOfWeekEnToKo(confirmedDateTime.getStartDateTime().getDayOfWeek());
         String startTime = confirmedDateTime.getStartDateTime().toLocalTime().toString();
         String endTime = confirmedDateTime.getEndDateTime().toLocalTime().toString();
 

--- a/src/main/java/com/asap/server/controller/dto/response/FixedMeetingResponseDto.java
+++ b/src/main/java/com/asap/server/controller/dto/response/FixedMeetingResponseDto.java
@@ -1,6 +1,10 @@
 package com.asap.server.controller.dto.response;
 
+import com.asap.server.domain.ConfirmedDateTime;
+import com.asap.server.domain.Meeting;
+import com.asap.server.domain.User;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,4 +24,34 @@ public class FixedMeetingResponseDto {
     private String hostName;
     private List<String> userNames;
     private String additionalInfo;
+
+    public static FixedMeetingResponseDto of(Meeting meeting) {
+        List<String> userNames = meeting
+                .getFixedUsers()
+                .stream()
+                .map(User::getName)
+                .collect(Collectors.toList());
+
+        ConfirmedDateTime confirmedDateTime = meeting.getConfirmedDateTime();
+        String month = String.valueOf(confirmedDateTime.getStartDateTime().getMonthValue());
+        String day = String.valueOf(confirmedDateTime.getStartDateTime().getDayOfMonth());
+        String dayOfWeek = confirmedDateTime.getStartDateTime().getDayOfWeek().toString();
+        String startTime = confirmedDateTime.getStartDateTime().toLocalTime().toString();
+        String endTime = confirmedDateTime.getEndDateTime().toLocalTime().toString();
+
+        return FixedMeetingResponseDto
+                .builder()
+                .title(meeting.getTitle())
+                .place(meeting.getPlace().toString())
+                .placeDetail(meeting.getPlace().getPlaceDetail())
+                .month(month)
+                .day(day)
+                .dayOfWeek(dayOfWeek)
+                .startTime(startTime)
+                .endTime(endTime)
+                .hostName(meeting.getHost().getName())
+                .userNames(userNames)
+                .additionalInfo(meeting.getAdditionalInfo())
+                .build();
+    }
 }

--- a/src/main/java/com/asap/server/domain/ConfirmedDateTime.java
+++ b/src/main/java/com/asap/server/domain/ConfirmedDateTime.java
@@ -4,12 +4,14 @@ import java.time.LocalDateTime;
 import javax.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @Embeddable
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ConfirmedTime {
-    private LocalDateTime startTime;
-    private LocalDateTime endTime;
+public class ConfirmedDateTime {
+    private LocalDateTime startDateTime;
+    private LocalDateTime endDateTime;
 }

--- a/src/main/java/com/asap/server/domain/Meeting.java
+++ b/src/main/java/com/asap/server/domain/Meeting.java
@@ -44,7 +44,7 @@ public class Meeting extends AuditingTimeEntity {
     @Embedded
     private Place place;
     @Embedded
-    private ConfirmedTime confirmedTime;
+    private ConfirmedDateTime confirmedDateTime;
 
     private Meeting(User host,
                     List<PreferTime> preferTimes,
@@ -84,7 +84,7 @@ public class Meeting extends AuditingTimeEntity {
         this.fixedUsers = users;
     }
 
-    public void setConfirmedTime(ConfirmedTime confirmedTime) {
-        this.confirmedTime = confirmedTime;
+    public void setConfirmedDateTime(ConfirmedDateTime confirmedDateTime) {
+        this.confirmedDateTime = confirmedDateTime;
     }
 }

--- a/src/main/java/com/asap/server/domain/Place.java
+++ b/src/main/java/com/asap/server/domain/Place.java
@@ -3,11 +3,13 @@ package com.asap.server.domain;
 import com.asap.server.domain.enums.PlaceType;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 
+@Getter
 @Embeddable
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/asap/server/exception/model/AsapException.java
+++ b/src/main/java/com/asap/server/exception/model/AsapException.java
@@ -5,13 +5,18 @@ import lombok.Getter;
 
 @Getter
 public class AsapException extends RuntimeException {
-    private final Error error;
+    private Error error;
 
-    public AsapException(Error error){
+    public AsapException(Error error) {
         super(error.getMessage());
         this.error = error;
     }
-    public int getHttpStatus(){
+
+    public AsapException(String msg) {
+        super(msg);
+    }
+
+    public int getHttpStatus() {
         return error.getHttpStatusCode();
     }
 }

--- a/src/main/java/com/asap/server/exception/model/BadRequestException.java
+++ b/src/main/java/com/asap/server/exception/model/BadRequestException.java
@@ -6,4 +6,8 @@ public class BadRequestException extends AsapException {
     public BadRequestException(Error error) {
         super(error);
     }
+
+    public BadRequestException(String msg) {
+        super(msg);
+    }
 }

--- a/src/main/java/com/asap/server/service/MeetingService.java
+++ b/src/main/java/com/asap/server/service/MeetingService.java
@@ -14,6 +14,7 @@ import com.asap.server.controller.dto.response.MeetingSaveResponseDto;
 import com.asap.server.controller.dto.response.MeetingScheduleResponseDto;
 import com.asap.server.controller.dto.response.PreferTimeResponseDto;
 import com.asap.server.controller.dto.response.TimeTableResponseDto;
+import com.asap.server.domain.ConfirmedDateTime;
 import com.asap.server.domain.Meeting;
 import com.asap.server.domain.PreferTime;
 import com.asap.server.domain.User;
@@ -30,15 +31,15 @@ import com.asap.server.repository.PreferTimeRepository;
 import com.asap.server.service.vo.MeetingTimeVo;
 import com.asap.server.service.vo.MeetingVo;
 import com.asap.server.service.vo.UserVo;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.Base64Utils;
-
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.Base64Utils;
 
 import static com.asap.server.exception.Error.INVALID_MEETING_HOST_EXCEPTION;
 
@@ -165,16 +166,23 @@ public class MeetingService {
                 .map(User::getName)
                 .collect(Collectors.toList());
 
+        ConfirmedDateTime confirmedDateTime = meeting.getConfirmedDateTime();
+        String month = String.valueOf(confirmedDateTime.getStartDateTime().getMonthValue());
+        String day = String.valueOf(confirmedDateTime.getStartDateTime().getDayOfMonth());
+        String dayOfWeek = confirmedDateTime.getStartDateTime().getDayOfWeek().toString();
+        String startTime = confirmedDateTime.getStartDateTime().toLocalTime().toString();
+        String endTime = confirmedDateTime.getEndDateTime().toLocalTime().toString();
+
         return FixedMeetingResponseDto
                 .builder()
                 .title(meeting.getTitle())
                 .place(meeting.getPlace().toString())
-                .placeDetail(meeting.getPlaceDetail())
-                .month(Integer.valueOf(meeting.getMonth()).toString())
-                .day(Integer.valueOf(meeting.getDay()).toString())
-                .dayOfWeek(meeting.getDayOfWeek())
-                .startTime(meeting.getStartTime().getTime())
-                .endTime(meeting.getEndTime().getTime())
+                .placeDetail(meeting.getPlace().getPlaceDetail())
+                .month(month)
+                .day(day)
+                .dayOfWeek(dayOfWeek)
+                .startTime(startTime)
+                .endTime(endTime)
                 .hostName(meeting.getHost().getName())
                 .userNames(userNames)
                 .additionalInfo(meeting.getAdditionalInfo())

--- a/src/main/java/com/asap/server/service/MeetingService.java
+++ b/src/main/java/com/asap/server/service/MeetingService.java
@@ -14,7 +14,6 @@ import com.asap.server.controller.dto.response.MeetingSaveResponseDto;
 import com.asap.server.controller.dto.response.MeetingScheduleResponseDto;
 import com.asap.server.controller.dto.response.PreferTimeResponseDto;
 import com.asap.server.controller.dto.response.TimeTableResponseDto;
-import com.asap.server.domain.ConfirmedDateTime;
 import com.asap.server.domain.Meeting;
 import com.asap.server.domain.PreferTime;
 import com.asap.server.domain.User;
@@ -31,7 +30,6 @@ import com.asap.server.repository.PreferTimeRepository;
 import com.asap.server.service.vo.MeetingTimeVo;
 import com.asap.server.service.vo.MeetingVo;
 import com.asap.server.service.vo.UserVo;
-import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -159,34 +157,7 @@ public class MeetingService {
     public FixedMeetingResponseDto getFixedMeetingInformation(Long meetingId) {
         Meeting meeting = meetingRepository.findById(meetingId)
                 .orElseThrow(() -> new NotFoundException(Error.MEETING_NOT_FOUND_EXCEPTION));
-
-        List<String> userNames = meeting
-                .getFixedUsers()
-                .stream()
-                .map(User::getName)
-                .collect(Collectors.toList());
-
-        ConfirmedDateTime confirmedDateTime = meeting.getConfirmedDateTime();
-        String month = String.valueOf(confirmedDateTime.getStartDateTime().getMonthValue());
-        String day = String.valueOf(confirmedDateTime.getStartDateTime().getDayOfMonth());
-        String dayOfWeek = confirmedDateTime.getStartDateTime().getDayOfWeek().toString();
-        String startTime = confirmedDateTime.getStartDateTime().toLocalTime().toString();
-        String endTime = confirmedDateTime.getEndDateTime().toLocalTime().toString();
-
-        return FixedMeetingResponseDto
-                .builder()
-                .title(meeting.getTitle())
-                .place(meeting.getPlace().toString())
-                .placeDetail(meeting.getPlace().getPlaceDetail())
-                .month(month)
-                .day(day)
-                .dayOfWeek(dayOfWeek)
-                .startTime(startTime)
-                .endTime(endTime)
-                .hostName(meeting.getHost().getName())
-                .userNames(userNames)
-                .additionalInfo(meeting.getAdditionalInfo())
-                .build();
+        return FixedMeetingResponseDto.of(meeting);
     }
 
     public TimeTableResponseDto getTimeTable(Long userId, Long meetingId) {


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #111 

## Key Changes 🔑
1. 내용
   - 큐카드 API 수정

## To Reviewers 📢
- Get Api 큐카드 가져올 때 userId 가 필요 없기도 하고, 이미 적용하고 있지 않은데 swagger에 401 이런거 있길래 삭제했습니다. 노션에도 해당 API `isToken` 체크 해제했습니다~
-  `@Getter` 수정
- LocalDateTime 을 통해 response 값 추출
