### PR TITLE
#168 [feat] 비밀번호 암호화 구현

### DIFF
--- a/src/main/java/com/asap/server/common/utils/PasswordEncryptionUtil.java
+++ b/src/main/java/com/asap/server/common/utils/PasswordEncryptionUtil.java
@@ -1,0 +1,51 @@
+package com.asap.server.common.utils;
+
+import com.asap.server.service.vo.PasswordInfoVo;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+
+public class PasswordEncryptionUtil {
+    private static final int SALT_SIZE = 16;
+    private static final MessageDigest sha256;
+
+    static {
+        try {
+            sha256 = MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static PasswordInfoVo encryptPassword(String password) {
+        String salt = getSalt();
+        String passwordWithSalt = password + salt;
+
+        sha256.update(passwordWithSalt.getBytes());
+        String encryptedPassword = byteToString(sha256.digest());
+        return new PasswordInfoVo(encryptedPassword, salt);
+    }
+
+    public static String encryptPassword(String password, String salt) {
+        String passwordWithSalt = password + salt;
+
+        sha256.update(passwordWithSalt.getBytes());
+        return byteToString(sha256.digest());
+    }
+
+    private static String getSalt() {
+        SecureRandom secureRandom = new SecureRandom();
+        byte[] temp = new byte[SALT_SIZE];
+        secureRandom.nextBytes(temp);
+        return byteToString(temp);
+    }
+
+    private static String byteToString(byte[] temp) {
+        StringBuilder sb = new StringBuilder();
+        for (byte t : temp) {
+            sb.append(String.format("%02x", t));
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/asap/server/domain/Meeting.java
+++ b/src/main/java/com/asap/server/domain/Meeting.java
@@ -32,8 +32,9 @@ public class Meeting extends AuditingTimeEntity {
     @Column(nullable = false)
     private String title;
 
+    @Embedded
     @Column(nullable = false)
-    private String password;
+    private PasswordInfo passwordInfo;
 
     @Column(nullable = false)
     private String additionalInfo;
@@ -54,7 +55,7 @@ public class Meeting extends AuditingTimeEntity {
     private ConfirmedDateTime confirmedDateTime;
 
     public boolean authenticateHost(final String name, final String password) {
-        return this.host.getName().equals(name) && this.password.equals(password);
+        return this.host.getName().equals(name) && this.passwordInfo.getPassword().equals(password);
     }
 
     public boolean authenticateHost(final Long userId) {

--- a/src/main/java/com/asap/server/domain/PasswordInfo.java
+++ b/src/main/java/com/asap/server/domain/PasswordInfo.java
@@ -2,6 +2,7 @@ package com.asap.server.domain;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -9,6 +10,7 @@ import javax.persistence.Column;
 import javax.persistence.Embeddable;
 
 @Getter
+@Builder
 @Embeddable
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/asap/server/domain/PasswordInfo.java
+++ b/src/main/java/com/asap/server/domain/PasswordInfo.java
@@ -1,0 +1,21 @@
+package com.asap.server.domain;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+
+@Getter
+@Embeddable
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PasswordInfo {
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private String salt;
+}

--- a/src/main/java/com/asap/server/service/MeetingService.java
+++ b/src/main/java/com/asap/server/service/MeetingService.java
@@ -2,18 +2,20 @@ package com.asap.server.service;
 
 import com.asap.server.common.utils.BestMeetingUtil;
 import com.asap.server.common.utils.DateUtil;
+import com.asap.server.common.utils.PasswordEncryptionUtil;
 import com.asap.server.config.jwt.JwtService;
 import com.asap.server.controller.dto.request.MeetingConfirmRequestDto;
 import com.asap.server.controller.dto.request.MeetingSaveRequestDto;
 import com.asap.server.controller.dto.response.AvailableDatesDto;
 import com.asap.server.controller.dto.response.BestMeetingTimeResponseDto;
 import com.asap.server.controller.dto.response.FixedMeetingResponseDto;
-import com.asap.server.controller.dto.response.MeetingTitleResponseDto;
 import com.asap.server.controller.dto.response.MeetingSaveResponseDto;
 import com.asap.server.controller.dto.response.MeetingScheduleResponseDto;
+import com.asap.server.controller.dto.response.MeetingTitleResponseDto;
 import com.asap.server.controller.dto.response.TimeTableResponseDto;
 import com.asap.server.domain.ConfirmedDateTime;
 import com.asap.server.domain.Meeting;
+import com.asap.server.domain.PasswordInfo;
 import com.asap.server.domain.Place;
 import com.asap.server.domain.User;
 import com.asap.server.domain.enums.Role;
@@ -24,6 +26,7 @@ import com.asap.server.exception.model.NotFoundException;
 import com.asap.server.exception.model.UnauthorizedException;
 import com.asap.server.repository.MeetingRepository;
 import com.asap.server.service.vo.BestMeetingTimeVo;
+import com.asap.server.service.vo.PasswordInfoVo;
 import com.asap.server.service.vo.TimeBlocksByDateVo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -50,10 +53,16 @@ public class MeetingService {
 
     @Transactional
     public MeetingSaveResponseDto create(final MeetingSaveRequestDto meetingSaveRequestDto) {
+        PasswordInfoVo passwordInfo = PasswordEncryptionUtil.encryptPassword(meetingSaveRequestDto.getPassword());
 
         Meeting meeting = Meeting.builder()
                 .title(meetingSaveRequestDto.getTitle())
-                .password(meetingSaveRequestDto.getPassword())
+                .passwordInfo(
+                        new PasswordInfo(
+                                passwordInfo.getEncryptedPassword(),
+                                passwordInfo.getSalt()
+                        )
+                )
                 .additionalInfo(meetingSaveRequestDto.getAdditionalInfo())
                 .duration(meetingSaveRequestDto.getDuration())
                 .place(

--- a/src/main/java/com/asap/server/service/UserService.java
+++ b/src/main/java/com/asap/server/service/UserService.java
@@ -1,5 +1,6 @@
 package com.asap.server.service;
 
+import com.asap.server.common.utils.PasswordEncryptionUtil;
 import com.asap.server.config.jwt.JwtService;
 import com.asap.server.controller.dto.request.AvailableTimeRequestDto;
 import com.asap.server.controller.dto.request.HostLoginRequestDto;
@@ -156,7 +157,8 @@ public class UserService {
         Meeting meeting = meetingRepository.findById(meetingId)
                 .orElseThrow(() -> new NotFoundException(Error.MEETING_NOT_FOUND_EXCEPTION));
 
-        if (!meeting.authenticateHost(requestDto.getName(), requestDto.getPassword()))
+        String encryptedPassword = PasswordEncryptionUtil.encryptPassword(requestDto.getPassword(), meeting.getPasswordInfo().getSalt());
+        if (!meeting.authenticateHost(requestDto.getName(), encryptedPassword))
             throw new UnauthorizedException(Error.INVALID_HOST_ID_PASSWORD_EXCEPTION);
 
         if (timeBlockUserService.isEmptyHostTimeBlock(meeting.getHost()))

--- a/src/main/java/com/asap/server/service/vo/PasswordInfoVo.java
+++ b/src/main/java/com/asap/server/service/vo/PasswordInfoVo.java
@@ -1,0 +1,11 @@
+package com.asap.server.service.vo;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PasswordInfoVo {
+    private String encryptedPassword;
+    private String salt;
+}

--- a/src/test/java/com/asap/server/common/utils/PasswordEncryptionUtilTest.java
+++ b/src/test/java/com/asap/server/common/utils/PasswordEncryptionUtilTest.java
@@ -1,0 +1,24 @@
+package com.asap.server.common.utils;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+public class PasswordEncryptionUtilTest {
+
+    @Test
+    @DisplayName("password 암호화 테스트")
+    public void test() {
+        // given
+        String password = "1234";
+        String salt = "salt";
+        String result = "4b3bed8af7b7612e8c1e25f63ba24496f5b16b2df44efb2db7ce3cb24b7e96f7";
+
+        // when
+        String encryptedPassword = PasswordEncryptionUtil.encryptPassword(password, salt);
+
+        // then
+        assertThat(encryptedPassword).isEqualTo(result);
+    }
+}


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #168 

## Key Changes 🔑
1. 내용
   - 비밀번호 암호화 Util 함수 구현
   - 회의 생성 api 내에 함수화 로직 적용
   - 방장 로그인 api 내에 함수화 로직 적용

## To Reviewers 📢
- [해당 블로그](https://st-lab.tistory.com/100) 참고 하면서 작업했습니다.
- 비밀번호에 소금 치면 더욱 암호화가 잘 될 것이라 기대되기에 table 내에 회의의 salt 를 저장하는 속성을 추가했습니다..!
