### PR TITLE
#183 [feat] 유저의 모든 request, response 로깅

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -33,7 +33,6 @@ jobs:
     - name: make application.properties 파일 생성
       run: |
         ## create application.yml
-        mkdir ./src/main/resources
         cd ./src/main/resources
 
         # application.yml 파일 생성
@@ -51,7 +50,7 @@ jobs:
       run: chmod +x gradlew
       
     - name: Build with Gradle # 실제 application build(-x 옵션을 통해 test는 제외)
-      run: ./gradlew build -x test
+      run: ./gradlew build -PactiveProfiles=local
       
     # 디렉토리 생성
     - name: Make Directory

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,6 @@ jobs:
     - name: make application.properties 파일 생성
       run: |
         ## create application.yml
-        rm -r ./src/main/resources
-        mkdir ./src/main/resources
         cd ./src/main/resources
 
         # application.yml 파일 생성
@@ -48,8 +46,5 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
       
-    - name: Build with Gradle # 실제 application build(-x 옵션을 통해 test는 제외)
-      run: ./gradlew build -x test
-    
-    - name: Test with Gradle
-      run: ./gradlew build test
+    - name: Build with Gradle # 실제 application build
+      run: ./gradlew build -PactiveProfiles=local

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
     - name: make application.properties 파일 생성
       run: |
         ## create application.yml
+        rm -r ./src/main/resources
+        mkdir ./src/main/resources
         cd ./src/main/resources
 
         # application.yml 파일 생성

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,6 @@ jobs:
     - name: make application.properties 파일 생성
       run: |
         ## create application.yml
-        mkdir ./src/main/resources
         cd ./src/main/resources
 
         # application.yml 파일 생성

--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -33,7 +33,6 @@ jobs:
     - name: make application.properties 파일 생성
       run: |
         ## create application.yml
-        mkdir ./src/main/resources
         cd ./src/main/resources
 
         # application.yml 파일 생성
@@ -50,8 +49,8 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
       
-    - name: Build with Gradle # 실제 application build(-x 옵션을 통해 test는 제외)
-      run: ./gradlew build -x test
+    - name: Build with Gradle # 실제 application build
+      run: ./gradlew build -PactiveProfiles=local
       
     # 디렉토리 생성
     - name: Make Directory

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
 	implementation 'org.springframework.security:spring-security-crypto:5.7.9'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/asap/server/ServerApplication.java
+++ b/src/main/java/com/asap/server/ServerApplication.java
@@ -3,9 +3,11 @@ package com.asap.server;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.web.servlet.ServletComponentScan;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
+@EnableAspectJAutoProxy
 @SpringBootApplication
 public class ServerApplication {
 

--- a/src/main/java/com/asap/server/common/advice/ControllerExceptionAdvice.java
+++ b/src/main/java/com/asap/server/common/advice/ControllerExceptionAdvice.java
@@ -5,6 +5,7 @@ import com.asap.server.common.utils.SlackUtil;
 import com.asap.server.exception.Error;
 import com.asap.server.exception.model.AsapException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
@@ -22,6 +23,7 @@ import java.io.IOException;
 
 import static com.asap.server.exception.Error.METHOD_NOT_ALLOWED_EXCEPTION;
 
+@Slf4j
 @RestControllerAdvice
 @RequiredArgsConstructor
 public class ControllerExceptionAdvice {
@@ -116,6 +118,7 @@ public class ControllerExceptionAdvice {
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(Exception.class)
     protected ErrorResponse handleException(final Exception error, final HttpServletRequest request) throws IOException {
+        log.error(error.getMessage(), error);
         slackUtil.sendAlert(error, request);
         return ErrorResponse.error(Error.INTERNAL_SERVER_ERROR);
     }

--- a/src/main/java/com/asap/server/common/aspect/LoggingAspect.java
+++ b/src/main/java/com/asap/server/common/aspect/LoggingAspect.java
@@ -1,0 +1,49 @@
+package com.asap.server.common.aspect;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+
+@Aspect
+@Component
+@Slf4j
+public class LoggingAspect {
+
+    @Pointcut("execution(* com.asap.server.controller..*(..)) || execution(* com.asap.server.common.advice..*(..))")
+    public void controllerExecute() {
+    }
+
+    @Around("com.asap.server.common.aspect.LoggingAspect.controllerExecute()")
+    public Object requestLogging(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
+        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+        long startAt = System.currentTimeMillis();
+        Object returnValue = proceedingJoinPoint.proceed(proceedingJoinPoint.getArgs());
+        long endAt = System.currentTimeMillis();
+        log.info("====> Request: {} {} ({}ms)\n *Header = {}\n", request.getMethod(), request.getRequestURL(), endAt - startAt, getHeaders(request));
+        if (returnValue != null) {
+            log.info("====> Response: {}\n", returnValue);
+        }
+        return returnValue;
+    }
+
+    private Map<String, Object> getHeaders(HttpServletRequest request) {
+        Map<String, Object> headerMap = new HashMap<>();
+
+        Enumeration<String> headerArray = request.getHeaderNames();
+        while (headerArray.hasMoreElements()) {
+            String headerName = headerArray.nextElement();
+            headerMap.put(headerName, request.getHeader(headerName));
+        }
+        return headerMap;
+    }
+}

--- a/src/main/java/com/asap/server/common/dto/ErrorResponse.java
+++ b/src/main/java/com/asap/server/common/dto/ErrorResponse.java
@@ -4,8 +4,10 @@ import com.asap.server.exception.Error;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 
 @Getter
+@ToString
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class ErrorResponse {
     private final int code;

--- a/src/main/java/com/asap/server/common/dto/SuccessResponse.java
+++ b/src/main/java/com/asap/server/common/dto/SuccessResponse.java
@@ -5,8 +5,10 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 
 @Getter
+@ToString
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access =  AccessLevel.PRIVATE)
 public class SuccessResponse<T> {

--- a/src/main/java/com/asap/server/controller/dto/response/AvailableDateResponseDto.java
+++ b/src/main/java/com/asap/server/controller/dto/response/AvailableDateResponseDto.java
@@ -3,9 +3,11 @@ package com.asap.server.controller.dto.response;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
 @Builder
+@ToString
 @AllArgsConstructor
 public class AvailableDateResponseDto {
     private String month;

--- a/src/main/java/com/asap/server/controller/dto/response/AvailableDatesDto.java
+++ b/src/main/java/com/asap/server/controller/dto/response/AvailableDatesDto.java
@@ -3,10 +3,12 @@ package com.asap.server.controller.dto.response;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 
 import java.util.List;
 
 @Getter
+@ToString
 @AllArgsConstructor
 @Builder
 public class AvailableDatesDto {

--- a/src/main/java/com/asap/server/controller/dto/response/BestMeetingTimeResponseDto.java
+++ b/src/main/java/com/asap/server/controller/dto/response/BestMeetingTimeResponseDto.java
@@ -3,11 +3,13 @@ package com.asap.server.controller.dto.response;
 import com.asap.server.service.vo.BestMeetingTimeVo;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.ToString;
 
 import java.util.Arrays;
 import java.util.List;
 
 @Getter
+@ToString
 @AllArgsConstructor
 public class BestMeetingTimeResponseDto {
     private int memberCount;

--- a/src/main/java/com/asap/server/controller/dto/response/FixedMeetingResponseDto.java
+++ b/src/main/java/com/asap/server/controller/dto/response/FixedMeetingResponseDto.java
@@ -4,10 +4,12 @@ import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
 @AllArgsConstructor
 @Builder
+@ToString
 public class FixedMeetingResponseDto {
     private String title;
     private String place;

--- a/src/main/java/com/asap/server/controller/dto/response/HostLoginResponseDto.java
+++ b/src/main/java/com/asap/server/controller/dto/response/HostLoginResponseDto.java
@@ -3,9 +3,11 @@ package com.asap.server.controller.dto.response;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
 @Builder
+@ToString
 @AllArgsConstructor
 public class HostLoginResponseDto {
     private String accessToken;

--- a/src/main/java/com/asap/server/controller/dto/response/MeetingSaveResponseDto.java
+++ b/src/main/java/com/asap/server/controller/dto/response/MeetingSaveResponseDto.java
@@ -3,9 +3,11 @@ package com.asap.server.controller.dto.response;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
 @Builder
+@ToString
 @AllArgsConstructor
 public class MeetingSaveResponseDto {
     private String url;

--- a/src/main/java/com/asap/server/controller/dto/response/MeetingScheduleResponseDto.java
+++ b/src/main/java/com/asap/server/controller/dto/response/MeetingScheduleResponseDto.java
@@ -5,10 +5,12 @@ import com.asap.server.domain.enums.PlaceType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 
 import java.util.List;
 
 @Getter
+@ToString
 @AllArgsConstructor
 @Builder
 public class MeetingScheduleResponseDto {

--- a/src/main/java/com/asap/server/controller/dto/response/MeetingTimeResponseDto.java
+++ b/src/main/java/com/asap/server/controller/dto/response/MeetingTimeResponseDto.java
@@ -6,10 +6,12 @@ import com.asap.server.service.vo.BestMeetingTimeVo;
 import com.asap.server.service.vo.UserVo;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.ToString;
 
 import java.util.List;
 
 @Getter
+@ToString
 @AllArgsConstructor
 public class MeetingTimeResponseDto {
     private String month;

--- a/src/main/java/com/asap/server/controller/dto/response/MeetingTitleResponseDto.java
+++ b/src/main/java/com/asap/server/controller/dto/response/MeetingTitleResponseDto.java
@@ -3,9 +3,11 @@ package com.asap.server.controller.dto.response;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
 @Builder
+@ToString
 @AllArgsConstructor
 public class MeetingTitleResponseDto {
     private String title;

--- a/src/main/java/com/asap/server/controller/dto/response/PreferTimeResponseDto.java
+++ b/src/main/java/com/asap/server/controller/dto/response/PreferTimeResponseDto.java
@@ -3,9 +3,11 @@ package com.asap.server.controller.dto.response;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
 @Builder
+@ToString
 @AllArgsConstructor
 public class PreferTimeResponseDto {
     private String startTime;

--- a/src/main/java/com/asap/server/controller/dto/response/TimeSlotDto.java
+++ b/src/main/java/com/asap/server/controller/dto/response/TimeSlotDto.java
@@ -3,9 +3,11 @@ package com.asap.server.controller.dto.response;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 
 import java.util.List;
 @Getter
+@ToString
 @AllArgsConstructor
 @Builder
 public class TimeSlotDto {

--- a/src/main/java/com/asap/server/controller/dto/response/TimeTableResponseDto.java
+++ b/src/main/java/com/asap/server/controller/dto/response/TimeTableResponseDto.java
@@ -3,10 +3,12 @@ package com.asap.server.controller.dto.response;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 
 import java.util.List;
 @Getter
 @Builder
+@ToString
 @AllArgsConstructor
 public class TimeTableResponseDto {
     public int memberCount;

--- a/src/main/java/com/asap/server/controller/dto/response/UserMeetingTimeResponseDto.java
+++ b/src/main/java/com/asap/server/controller/dto/response/UserMeetingTimeResponseDto.java
@@ -3,9 +3,11 @@ package com.asap.server.controller.dto.response;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
 @Builder
+@ToString
 @AllArgsConstructor
 public class UserMeetingTimeResponseDto {
     private String url;

--- a/src/main/java/com/asap/server/controller/dto/response/UserTimeResponseDto.java
+++ b/src/main/java/com/asap/server/controller/dto/response/UserTimeResponseDto.java
@@ -3,9 +3,11 @@ package com.asap.server.controller.dto.response;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
 @Builder
+@ToString
 @AllArgsConstructor
 public class UserTimeResponseDto {
     private String role;

--- a/src/main/java/com/asap/server/service/vo/BestMeetingTimeVo.java
+++ b/src/main/java/com/asap/server/service/vo/BestMeetingTimeVo.java
@@ -4,11 +4,13 @@ import com.asap.server.domain.enums.TimeSlot;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.ToString;
 
 import java.time.LocalDate;
 import java.util.List;
 
 @Getter
+@ToString
 @AllArgsConstructor
 @EqualsAndHashCode
 public class BestMeetingTimeVo {

--- a/src/main/java/com/asap/server/service/vo/TimeBlocksByDateVo.java
+++ b/src/main/java/com/asap/server/service/vo/TimeBlocksByDateVo.java
@@ -4,11 +4,13 @@ package com.asap.server.service.vo;
 import com.asap.server.domain.AvailableDate;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.ToString;
 
 import java.time.LocalDate;
 import java.util.List;
 
 @Getter
+@ToString
 @AllArgsConstructor
 public class TimeBlocksByDateVo {
     private Long id;

--- a/src/main/java/com/asap/server/service/vo/TimeSlotInfoDto.java
+++ b/src/main/java/com/asap/server/service/vo/TimeSlotInfoDto.java
@@ -4,7 +4,9 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
+@ToString
 @NoArgsConstructor
 @Getter
 public class TimeSlotInfoDto {

--- a/src/main/java/com/asap/server/service/vo/UserVo.java
+++ b/src/main/java/com/asap/server/service/vo/UserVo.java
@@ -3,8 +3,10 @@ package com.asap.server.service.vo;
 import com.asap.server.domain.User;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
+@ToString
 @AllArgsConstructor
 public class UserVo {
     private Long id;

--- a/src/main/resources/console-appender.xml
+++ b/src/main/resources/console-appender.xml
@@ -1,0 +1,7 @@
+<included>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+</included>

--- a/src/main/resources/file-error-appender.xml
+++ b/src/main/resources/file-error-appender.xml
@@ -1,0 +1,19 @@
+<included>
+    <appender name="FILE-ERROR" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>/home/ubuntu/app/logs/error/error-${BY_DATE}.log</file>
+        <filter class = "ch.qos.logback.classic.filter.LevelFilter">
+            <level>ERROR</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern> /home/ubuntu/app/logs/error/error-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxHistory>30</maxHistory>
+            <totalSizeCap>3GB</totalSizeCap>
+            <maxFileSize>10MB</maxFileSize>
+        </rollingPolicy>
+    </appender>
+</included>

--- a/src/main/resources/file-info-appender.xml
+++ b/src/main/resources/file-info-appender.xml
@@ -1,0 +1,19 @@
+<included>
+    <appender name="FILE-INFO" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>/home/ubuntu/app/logs/info/info-${BY_DATE}.log</file>
+        <filter class = "ch.qos.logback.classic.filter.LevelFilter">
+            <level>INFO</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern> /home/ubuntu/app/logs/info/info-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxHistory>30</maxHistory>
+            <totalSizeCap>3GB</totalSizeCap>
+            <maxFileSize>10MB</maxFileSize>
+        </rollingPolicy>
+    </appender>
+</included>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,24 @@
+<configuration>
+    <timestamp key="BY_DATE" datePattern="yyyy-MM-dd"/>
+    <property name="LOG_PATTERN"
+              value="[%d{yyyy-MM-dd HH:mm:ss}:%-4relative] %green([%thread]) %highlight(%-5level) %boldWhite([%C.%M:%yellow(%L)]) - %msg%n"/>
+
+    <springProfile name="local">
+        <include resource="console-appender.xml"/>
+
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="!local">
+        <include resource="file-info-appender.xml"/>
+        <include resource="file-error-appender.xml"/>
+
+        <root level="INFO">
+            <appender-ref ref="FILE-INFO"/>
+            <appender-ref ref="FILE-ERROR"/>
+        </root>
+    </springProfile>
+
+</configuration>


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #183 

## Key Changes 🔑
1. 내용
   - 유저의 모든 request, response 로깅
   - [하우스 pr](https://github.com/Hous-Release/hous-server/pull/293) 참고해서 구현해봤습니다

## To Reviewers 📢
```java
[2023-09-19 21:47:43:64967] [32m[http-nio-8080-exec-1][0;39m [34mINFO [0;39m [1;37m[com.asap.server.common.aspect.LoggingAspect.requestLogging:[33m32[0;39m][0;39m - ====> Request: POST http://localhost:8080/meeting (180ms)
 *Header = {sec-fetch-mode=cors, content-length=305, referer=http://localhost:8080/swagger-ui/index.html, sec-fetch-site=same-origin, accept-language=ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7, origin=http://localhost:8080, accept=application/json;charset=UTF-8, sec-ch-ua="Chromium";v="116", "Not)A;Brand";v="24", "Google Chrome";v="116", sec-ch-ua-mobile=?0, sec-ch-ua-platform="Windows", host=localhost:8080, connection=keep-alive, content-type=application/json;charset=UTF-8, accept-encoding=gzip, deflate, br, user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36, sec-fetch-dest=empty}

[2023-09-19 21:47:43:64968] [32m[http-nio-8080-exec-1][0;39m [34mINFO [0;39m [1;37m[com.asap.server.common.aspect.LoggingAspect.requestLogging:[33m34[0;39m][0;39m - ====> Response: SuccessResponse(code=201, message=회의가 성공적으로 생성되었습니다., data=MeetingSaveResponseDto(url=MTQ=, accessToken=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzM4NCJ9.eyJzdWIiOiJhY2Nlc3NfdG9rZW4iLCJpYXQiOjE2OTUxMjc2NjMsImV4cCI6MTY5NTIxNDA2MywidXNlcklkIjoiMTciLCJyb2xlIjoiSE9TVCJ9.B57RSxSjbqa4rO_pfqfiEitkYRYI6U2jM8-iDPeFRznyZD7qFEN3ICObGdAQxkKg))
```

현재 request 시 header 값과 request 결과를 로깅하고 있습니다.
body 값도 로깅에 추가하고 싶었지만 , body 값은 필터에서 한번밖에 조회할 수 있어서
body 값도 로깅하려면 custom filter 를 만들어야 하기 때문에 나중에 필요할 때 추가해보겠습니다.

```java
[2023-09-19 21:52:46:7233] [32m[http-nio-8080-exec-1][0;39m [1;31mERROR[0;39m [1;37m[com.asap.server.common.advice.ControllerExceptionAdvice.handleException:[33m121[0;39m][0;39m - Request method 'GET' not supported
org.springframework.web.HttpRequestMethodNotSupportedException: Request method 'GET' not supported
	at org.springframework.web.servlet.mvc.method.RequestMappingInfoHandlerMapping.handleNoMatch(RequestMappingInfoHandlerMapping.java:260)
	at org.springframework.web.servlet.handler.AbstractHandlerMethodMapping.lookupHandlerMethod(AbstractHandlerMethodMapping.java:442)
	at org.springframework.web.servlet.handler.AbstractHandlerMethodMapping.getHandlerInternal(AbstractHandlerMethodMapping.java:383)
	at org.springframework.web.servlet.mvc.method.RequestMappingInfoHandlerMapping.getHandlerInternal(RequestMappingInfoHandlerMapping.java:125)
	at org.springframework.web.servlet.mvc.method.RequestMappingInfoHandlerMapping.getHandlerInternal(RequestMappingInfoHandlerMapping.java:67)
	at org.springframework.web.servlet.handler.AbstractHandlerMapping.getHandler(AbstractHandlerMapping.java:498)
	at org.springframework.web.servlet.DispatcherServlet.getHandler(DispatcherServlet.java:1266)
	at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:1048)
	at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:965)
	at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:1006)
	at org.springframework.web.servlet.FrameworkServlet.doGet(FrameworkServlet.java:898)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:529)
	at org.springframework.web.servlet.FrameworkServlet.service(FrameworkServlet.java:883)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:623)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:209)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:153)
	at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:51)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:178)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:153)
	at org.springframework.web.filter.RequestContextFilter.doFilterInternal(RequestContextFilter.java:100)
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:117)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:178)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:153)
	at org.springframework.web.filter.FormContentFilter.doFilterInternal(FormContentFilter.java:93)
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:117)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:178)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:153)
	at org.springframework.boot.actuate.metrics.web.servlet.WebMvcMetricsFilter.doFilterInternal(WebMvcMetricsFilter.java:96)
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:117)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:178)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:153)
	at org.springframework.web.filter.CharacterEncodingFilter.doFilterInternal(CharacterEncodingFilter.java:201)
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:117)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:178)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:153)
	at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:167)
	at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:90)
	at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:481)
	at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:130)
	at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:93)
	at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:74)
	at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:343)
	at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:390)
	at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:63)
	at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:926)
	at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1791)
	at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:52)
	at org.apache.tomcat.util.threads.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1191)
	at org.apache.tomcat.util.threads.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:659)
	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
	at java.base/java.lang.Thread.run(Thread.java:833)
```
에러와 같은 경우는 위와 같이 저장됩니다!

---

그리고 파일에 객체 정보를 저장하기 위해서 dto 들은 싹 다 toString 어노테이션 붙였습니다!
dto 들은 이제 toString 어노테이션 붙이면 될 것 같습니다 ~ !

---

깃허브 액션 파일도 수정 사항이 있는게
저희가 로그 파일을 독립적인 공간에다가 따로 생성을 하는데, 테스트 코드를 돌릴 때 이게 에러가 생기나봐요..
그래서 ci 돌릴 땐 resource 내부에 있는 로그 관련 파일들을 전부 삭제하고 돌리는 방향으로 수정했습니다.
![image](https://github.com/ASAP-as-soon-as-possible/ASAP_Server/assets/82709044/c7f06a40-3b4b-4c03-99c8-1a39b1dd4440)

[참고 블로그](https://unagi-zoso.tistory.com/257)