### PR TITLE
#193 [feat] 최적의 회의시간 도출 로직 수정

### DIFF
--- a/src/main/java/com/asap/server/common/utils/BestMeetingUtil.java
+++ b/src/main/java/com/asap/server/common/utils/BestMeetingUtil.java
@@ -48,20 +48,21 @@ public class BestMeetingUtil {
         List<TimeBlockVo> sortedTimeBlocks = filterByUserCountAndSortByTime(timeBlocksByDate.getTimeBlocks(), userCount);
 
         List<BestMeetingTimeVo> bestMeetingTimes = new ArrayList<>();
-        int endIndex = sortedTimeBlocks.size() - needTimeBlockCount;
+        int endIndex = sortedTimeBlocks.size() - needTimeBlockCount + 1;
         for (int timeBlockIdx = 0; timeBlockIdx < endIndex; timeBlockIdx++) {
             if (!isBestMeetingTime(sortedTimeBlocks, timeBlockIdx, needTimeBlockCount)) continue;
 
             int sumWeight = sortedTimeBlocks
-                    .subList(timeBlockIdx, timeBlockIdx + needTimeBlockCount + 1)
+                    .subList(timeBlockIdx, timeBlockIdx + needTimeBlockCount)
                     .stream()
                     .map(TimeBlockVo::getWeight)
                     .reduce(0, Integer::sum);
 
+            TimeSlot startTime = sortedTimeBlocks.get(timeBlockIdx).getTimeSlot();
             BestMeetingTimeVo bestMeetingTime = new BestMeetingTimeVo(
                     timeBlocksByDate.getDate(),
-                    sortedTimeBlocks.get(timeBlockIdx).getTimeSlot(),
-                    sortedTimeBlocks.get(timeBlockIdx + needTimeBlockCount).getTimeSlot(),
+                    startTime,
+                    TimeSlot.getTimeSlot(startTime.ordinal() + needTimeBlockCount),
                     sortedTimeBlocks.get(timeBlockIdx).getUsers(),
                     sumWeight
             );
@@ -81,7 +82,7 @@ public class BestMeetingUtil {
     private boolean isBestMeetingTime(final List<TimeBlockVo> timeBlocks, final int timeBlockIdx, final int needTimeBlockCount) {
         boolean isBestMeetingTime = true;
         TimeSlot nextTime = timeBlocks.get(timeBlockIdx).getTimeSlot();
-        for (int i = timeBlockIdx + 1; i <= timeBlockIdx + needTimeBlockCount; i++) {
+        for (int i = timeBlockIdx + 1; i < timeBlockIdx + needTimeBlockCount; i++) {
             if (nextTime.ordinal() + 1 != timeBlocks.get(i).getTimeSlot().ordinal()) {
                 isBestMeetingTime = false;
                 break;

--- a/src/main/java/com/asap/server/domain/enums/TimeSlot.java
+++ b/src/main/java/com/asap/server/domain/enums/TimeSlot.java
@@ -68,6 +68,15 @@ public enum TimeSlot {
         return result;
     }
 
+    // 특정 ordinal 의 time slot 반환
+    public static TimeSlot getTimeSlot(int ordinal) {
+        TimeSlot[] timeSlots = TimeSlot.values();
+        for (TimeSlot t : timeSlots) {
+            if (t.ordinal() == ordinal) return t;
+        }
+        return null;
+    }
+
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static TimeSlot findByTime(String timeSlot) {
         return Stream.of(TimeSlot.values())

--- a/src/test/java/com/asap/server/common/utils/GetBestMeetingTimeTest.java
+++ b/src/test/java/com/asap/server/common/utils/GetBestMeetingTimeTest.java
@@ -19,6 +19,7 @@ import static com.asap.server.domain.enums.TimeSlot.SLOT_12_30;
 import static com.asap.server.domain.enums.TimeSlot.SLOT_13_00;
 import static com.asap.server.domain.enums.TimeSlot.SLOT_13_30;
 import static com.asap.server.domain.enums.TimeSlot.SLOT_14_00;
+import static com.asap.server.domain.enums.TimeSlot.SLOT_14_30;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 public class GetBestMeetingTimeTest {
@@ -37,15 +38,12 @@ public class GetBestMeetingTimeTest {
         List<UserVo> users = List.of(userVo);
 
         TimeBlockVo timeBlockByMeetingDate = new TimeBlockVo(1L, 0, SLOT_12_00, users);
-        TimeBlockVo timeBlock2ByMeetingDate = new TimeBlockVo(1L, 0, SLOT_12_30, users);
-        List<TimeBlockVo> timeBlocks = new ArrayList<>(Arrays.asList(timeBlockByMeetingDate, timeBlock2ByMeetingDate));
+        List<TimeBlockVo> timeBlocks = new ArrayList<>(Arrays.asList(timeBlockByMeetingDate));
 
         LocalDate meetingDate = LocalDate.of(2023, 7, 10);
-        LocalDate meetingDate2 = LocalDate.of(2023, 7, 11);
 
         TimeBlocksByDateVo timeBlocksByDate = new TimeBlocksByDateVo(1L, meetingDate, timeBlocks);
-        TimeBlocksByDateVo timeBlocksByDate2 = new TimeBlocksByDateVo(2L, meetingDate2, new ArrayList<>());
-        List<TimeBlocksByDateVo> timeBlocksByDates = Arrays.asList(timeBlocksByDate, timeBlocksByDate2);
+        List<TimeBlocksByDateVo> timeBlocksByDates = Arrays.asList(timeBlocksByDate);
 
         BestMeetingTimeVo result = new BestMeetingTimeVo(meetingDate, SLOT_12_00, SLOT_12_30, users, 0);
 
@@ -67,12 +65,10 @@ public class GetBestMeetingTimeTest {
         LocalDate meetingDate2 = LocalDate.of(2023, 7, 11);
 
         TimeBlockVo timeBlockByMeetingDate = new TimeBlockVo(1L, 0, SLOT_12_00, users);
-        TimeBlockVo timeBlock2ByMeetingDate = new TimeBlockVo(1L, 0, SLOT_12_30, users);
-        List<TimeBlockVo> timeBlocks = new ArrayList<>(Arrays.asList(timeBlockByMeetingDate, timeBlock2ByMeetingDate));
+        List<TimeBlockVo> timeBlocks = new ArrayList<>(Arrays.asList(timeBlockByMeetingDate));
 
         TimeBlockVo timeBlockByMeetingDate2 = new TimeBlockVo(1L, 0, SLOT_12_30, users);
-        TimeBlockVo timeBlock2ByMeetingDate2 = new TimeBlockVo(1L, 0, SLOT_13_00, users);
-        List<TimeBlockVo> timeBlocks2 = new ArrayList<>(Arrays.asList(timeBlockByMeetingDate2, timeBlock2ByMeetingDate2));
+        List<TimeBlockVo> timeBlocks2 = new ArrayList<>(Arrays.asList(timeBlockByMeetingDate2));
 
         TimeBlocksByDateVo timeBlocksByDate = new TimeBlocksByDateVo(1L, meetingDate, timeBlocks);
         TimeBlocksByDateVo timeBlocksByDate2 = new TimeBlocksByDateVo(2L, meetingDate2, timeBlocks2);
@@ -105,16 +101,15 @@ public class GetBestMeetingTimeTest {
 
         TimeBlockVo timeBlockByMeetingDate2 = new TimeBlockVo(1L, 0, SLOT_12_30, users);
         TimeBlockVo timeBlock2ByMeetingDate2 = new TimeBlockVo(1L, 0, SLOT_13_00, users);
-        TimeBlockVo timeBlock3ByMeetingDate2 = new TimeBlockVo(1L, 0, SLOT_13_30, users);
-        List<TimeBlockVo> timeBlocks2 = new ArrayList<>(Arrays.asList(timeBlockByMeetingDate2, timeBlock2ByMeetingDate2, timeBlock3ByMeetingDate2));
+        List<TimeBlockVo> timeBlocks2 = new ArrayList<>(Arrays.asList(timeBlockByMeetingDate2, timeBlock2ByMeetingDate2));
 
         TimeBlocksByDateVo timeBlocksByDate = new TimeBlocksByDateVo(1L, meetingDate, timeBlocks);
         TimeBlocksByDateVo timeBlocksByDate2 = new TimeBlocksByDateVo(2L, meetingDate2, timeBlocks2);
         List<TimeBlocksByDateVo> timeBlocksByDates = Arrays.asList(timeBlocksByDate, timeBlocksByDate2);
 
         BestMeetingTimeVo result = new BestMeetingTimeVo(meetingDate, SLOT_12_00, SLOT_12_30, users, 0);
-        BestMeetingTimeVo result2 = new BestMeetingTimeVo(meetingDate2, SLOT_12_30, SLOT_13_00, users, 0);
-        BestMeetingTimeVo result3 = new BestMeetingTimeVo(meetingDate2, SLOT_13_00, SLOT_13_30, users, 0);
+        BestMeetingTimeVo result2 = new BestMeetingTimeVo(meetingDate, SLOT_12_30, SLOT_13_00, users, 0);
+        BestMeetingTimeVo result3 = new BestMeetingTimeVo(meetingDate2, SLOT_12_30, SLOT_13_00, users, 0);
 
         // when
         List<BestMeetingTimeVo> bestMeetingTimes = bestMeetingUtil.getBestMeetingTime(timeBlocksByDates, Duration.HALF, 2);
@@ -136,13 +131,11 @@ public class GetBestMeetingTimeTest {
 
         TimeBlockVo timeBlockByMeetingDate = new TimeBlockVo(1L, 0, SLOT_12_00, users);
         TimeBlockVo timeBlock2ByMeetingDate = new TimeBlockVo(1L, 0, SLOT_12_30, users);
-        TimeBlockVo timeBlock3ByMeetingDate = new TimeBlockVo(1L, 0, SLOT_13_00, users);
-        List<TimeBlockVo> timeBlocks = new ArrayList<>(Arrays.asList(timeBlockByMeetingDate, timeBlock2ByMeetingDate, timeBlock3ByMeetingDate));
+        List<TimeBlockVo> timeBlocks = new ArrayList<>(Arrays.asList(timeBlockByMeetingDate, timeBlock2ByMeetingDate));
 
         TimeBlockVo timeBlockByMeetingDate2 = new TimeBlockVo(1L, 0, SLOT_12_30, users);
         TimeBlockVo timeBlock2ByMeetingDate2 = new TimeBlockVo(1L, 0, SLOT_13_00, users);
-        TimeBlockVo timeBlock3ByMeetingDate2 = new TimeBlockVo(1L, 0, SLOT_13_30, users);
-        List<TimeBlockVo> timeBlocks2 = new ArrayList<>(Arrays.asList(timeBlockByMeetingDate2, timeBlock2ByMeetingDate2, timeBlock3ByMeetingDate2));
+        List<TimeBlockVo> timeBlocks2 = new ArrayList<>(Arrays.asList(timeBlockByMeetingDate2, timeBlock2ByMeetingDate2));
 
         TimeBlocksByDateVo timeBlocksByDate = new TimeBlocksByDateVo(1L, meetingDate, timeBlocks);
         TimeBlocksByDateVo timeBlocksByDate2 = new TimeBlocksByDateVo(2L, meetingDate2, timeBlocks2);
@@ -186,12 +179,12 @@ public class GetBestMeetingTimeTest {
         TimeBlocksByDateVo timeBlocksByDate2 = new TimeBlocksByDateVo(2L, meetingDate2, timeBlocks2);
         List<TimeBlocksByDateVo> timeBlocksByDates = Arrays.asList(timeBlocksByDate, timeBlocksByDate2);
 
-        BestMeetingTimeVo result = new BestMeetingTimeVo(meetingDate2, SLOT_13_00, SLOT_14_00, users, 18);
-        BestMeetingTimeVo result2 = new BestMeetingTimeVo(meetingDate2, SLOT_12_30, SLOT_13_30, users, 12);
-        BestMeetingTimeVo result3 = new BestMeetingTimeVo(meetingDate, SLOT_12_00, SLOT_13_00, users, 0);
+        BestMeetingTimeVo result = new BestMeetingTimeVo(meetingDate2, SLOT_13_00, SLOT_14_30, users, 18);
+        BestMeetingTimeVo result2 = new BestMeetingTimeVo(meetingDate2, SLOT_12_30, SLOT_14_00, users, 12);
+        BestMeetingTimeVo result3 = new BestMeetingTimeVo(meetingDate, SLOT_12_00, SLOT_13_30, users, 0);
 
         // when
-        List<BestMeetingTimeVo> bestMeetingTimes = bestMeetingUtil.getBestMeetingTime(timeBlocksByDates, Duration.HOUR, 2);
+        List<BestMeetingTimeVo> bestMeetingTimes = bestMeetingUtil.getBestMeetingTime(timeBlocksByDates, Duration.HOUR_HALF, 2);
 
         // then
         assertThat(bestMeetingTimes).isEqualTo(Arrays.asList(result, result2, result3));

--- a/src/test/java/com/asap/server/common/utils/GetBestMeetingTimeTest.java
+++ b/src/test/java/com/asap/server/common/utils/GetBestMeetingTimeTest.java
@@ -189,4 +189,28 @@ public class GetBestMeetingTimeTest {
         // then
         assertThat(bestMeetingTimes).isEqualTo(Arrays.asList(result, result2, result3));
     }
+
+    @Test
+    @DisplayName("회의 시간이 30분이고, time block 이 1개 일 때, (해당 시간, null, null) 을 반환한다.")
+    public void getBestMeetingTime6() {
+        // given
+        UserVo userVo = new UserVo(1L, "강원용");
+        List<UserVo> users = Arrays.asList(userVo);
+
+        LocalDate meetingDate = LocalDate.of(2023, 7, 10);
+
+        TimeBlockVo timeBlockByMeetingDate = new TimeBlockVo(1L, 0, SLOT_12_00, users);
+        List<TimeBlockVo> timeBlocks = new ArrayList<>(Arrays.asList(timeBlockByMeetingDate));
+
+        TimeBlocksByDateVo timeBlocksByDate = new TimeBlocksByDateVo(1L, meetingDate, timeBlocks);
+        List<TimeBlocksByDateVo> timeBlocksByDates = Arrays.asList(timeBlocksByDate);
+
+        BestMeetingTimeVo result = new BestMeetingTimeVo(meetingDate, SLOT_12_00, SLOT_12_30, users, 0);
+
+        // when
+        List<BestMeetingTimeVo> bestMeetingTimes = bestMeetingUtil.getBestMeetingTime(timeBlocksByDates, Duration.HALF, 2);
+
+        // then
+        assertThat(bestMeetingTimes).isEqualTo(Arrays.asList(result, null, null));
+    }
 }

--- a/src/test/java/com/asap/server/common/utils/SearchBestMeetingTest.java
+++ b/src/test/java/com/asap/server/common/utils/SearchBestMeetingTest.java
@@ -21,9 +21,11 @@ import static com.asap.server.domain.enums.TimeSlot.SLOT_12_30;
 import static com.asap.server.domain.enums.TimeSlot.SLOT_13_00;
 import static com.asap.server.domain.enums.TimeSlot.SLOT_13_30;
 import static com.asap.server.domain.enums.TimeSlot.SLOT_14_00;
+import static com.asap.server.domain.enums.TimeSlot.SLOT_14_30;
 import static com.asap.server.domain.enums.TimeSlot.SLOT_20_00;
 import static com.asap.server.domain.enums.TimeSlot.SLOT_20_30;
 import static com.asap.server.domain.enums.TimeSlot.SLOT_21_00;
+import static com.asap.server.domain.enums.TimeSlot.SLOT_21_30;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 public class SearchBestMeetingTest {
@@ -57,7 +59,8 @@ public class SearchBestMeetingTest {
         BestMeetingTimeVo bestMeetingTime = new BestMeetingTimeVo(meetingDate, SLOT_11_00, SLOT_13_00, users, 0);
         BestMeetingTimeVo bestMeetingTime2 = new BestMeetingTimeVo(meetingDate, SLOT_11_30, SLOT_13_30, users, 0);
         BestMeetingTimeVo bestMeetingTime3 = new BestMeetingTimeVo(meetingDate, SLOT_12_00, SLOT_14_00, users, 0);
-        List<BestMeetingTimeVo> bestMeetingTimes = new ArrayList<>(List.of(bestMeetingTime, bestMeetingTime2, bestMeetingTime3));
+        BestMeetingTimeVo bestMeetingTime4 = new BestMeetingTimeVo(meetingDate, SLOT_12_30, SLOT_14_30, users, 0);
+        List<BestMeetingTimeVo> bestMeetingTimes = new ArrayList<>(List.of(bestMeetingTime, bestMeetingTime2, bestMeetingTime3, bestMeetingTime4));
 
         // when
         List<BestMeetingTimeVo> result = bestMeetingUtil.searchBestMeetingTime(availableDate, Duration.TWO_HOUR.getNeedBlock(), 2);
@@ -91,8 +94,10 @@ public class SearchBestMeetingTest {
         TimeBlocksByDateVo availableDate = new TimeBlocksByDateVo(1L, meetingDate, timeBlocks);
 
         BestMeetingTimeVo bestMeetingTime = new BestMeetingTimeVo(meetingDate, SLOT_11_00, SLOT_12_00, users, 0);
-        BestMeetingTimeVo bestMeetingTime2 = new BestMeetingTimeVo(meetingDate, SLOT_20_00, SLOT_21_00, users, 0);
-        List<BestMeetingTimeVo> bestMeetingTimes = new ArrayList<>(List.of(bestMeetingTime, bestMeetingTime2));
+        BestMeetingTimeVo bestMeetingTime2 = new BestMeetingTimeVo(meetingDate, SLOT_11_30, SLOT_12_30, users, 0);
+        BestMeetingTimeVo bestMeetingTime3 = new BestMeetingTimeVo(meetingDate, SLOT_20_00, SLOT_21_00, users, 0);
+        BestMeetingTimeVo bestMeetingTime4 = new BestMeetingTimeVo(meetingDate, SLOT_20_30, SLOT_21_30, users, 0);
+        List<BestMeetingTimeVo> bestMeetingTimes = new ArrayList<>(List.of(bestMeetingTime, bestMeetingTime2, bestMeetingTime3, bestMeetingTime4));
 
         // when
         List<BestMeetingTimeVo> result = bestMeetingUtil.searchBestMeetingTime(availableDate, Duration.HOUR.getNeedBlock(), 2);


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #193 

## Key Changes 🔑
1. 내용
   - 최적의 회의시간 도출 로직 수정

## To Reviewers 📢
time block 이 "09:00" 일 땐 09:00 ~ 09:30 인 것을 적용한 로직 입니다.
