### PR TITLE
#199 [fix] user id 인증 방식 개선

### DIFF
--- a/src/main/java/com/asap/server/config/resolver/user/UserIdResolver.java
+++ b/src/main/java/com/asap/server/config/resolver/user/UserIdResolver.java
@@ -4,8 +4,6 @@ import com.asap.server.config.jwt.JwtService;
 import com.asap.server.exception.Error;
 import com.asap.server.exception.model.BadRequestException;
 import com.asap.server.exception.model.UnauthorizedException;
-import javax.servlet.http.HttpServletRequest;
-import javax.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
@@ -13,6 +11,9 @@ import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.constraints.NotNull;
 
 @RequiredArgsConstructor
 @Component
@@ -28,10 +29,10 @@ public class UserIdResolver implements HandlerMethodArgumentResolver {
     public Object resolveArgument(@NotNull MethodParameter parameter, ModelAndViewContainer modelAndViewContainer, @NotNull NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
         final HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
         final String token = request.getHeader("Authorization");
-        if (token == null || token.isBlank()) {
+        if (token == null || token.isBlank() || !token.startsWith("Bearer ")) {
             throw new UnauthorizedException(Error.TOKEN_NOT_CONTAINED_EXCEPTION);
         }
-        final String encodedUserId = token.split(" ")[1];
+        final String encodedUserId = token.substring("Bearer ".length());
         if (!jwtService.verifyToken(encodedUserId)) {
             throw new UnauthorizedException(Error.EXPIRE_TOKEN_EXCEPTION);
         }


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #199 

## Key Changes 🔑
1. 내용
   - "Bearer " 만 들어왔을 때 split[1] 을 했을 시 null point exception 으로 인한 500 에러를 막기 위한 로직입니다. 

## To Reviewers 📢
-
