### PR TITLE
#196 [fix] 방장 회의 가능 시간 입력 넘어오지 않았을 때 에러 처리

### DIFF
--- a/src/main/java/com/asap/server/controller/UserController.java
+++ b/src/main/java/com/asap/server/controller/UserController.java
@@ -26,6 +26,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 import java.util.List;
 
 @Tag(name = "사용자", description = "사용자 관련 로그인 및 가능 시간 입력 API 입니다.")
@@ -57,7 +58,7 @@ public class UserController {
     @PostMapping("/host/{meetingId}/time")
     public SuccessResponse createHostTime(
             @Parameter(schema = @Schema(implementation = String.class), in = ParameterIn.PATH) @MeetingPathVariable final Long meetingId,
-            @RequestBody final List<@Valid UserMeetingTimeSaveRequestDto> requestDtoList,
+            @RequestBody final List<@Valid @NotNull UserMeetingTimeSaveRequestDto> requestDtoList,
             @UserId @Parameter(hidden = true) final Long userId
     ) {
         return SuccessResponse.success(Success.CREATE_HOST_TIME_SUCCESS, userService.createHostTime(meetingId, userId, requestDtoList));


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #196 

## Key Changes 🔑
1. 방장 회의 가능시간의 경우 List<Dto> 형식으로 받는건데 List안에 null 값이 넘어올 경우를 예외 처리 해놓지 않았더라고요! 그래서 했습니다! 간단한 문제였네요!

## To Reviewers 📢
- 로그 짱!!
