### PR TITLE
#208 [feat] 회의 확정 후 불필요한 데이터 삭제 로직 구현

### DIFF
--- a/src/main/java/com/asap/server/repository/AvailableDateRepository.java
+++ b/src/main/java/com/asap/server/repository/AvailableDateRepository.java
@@ -2,7 +2,10 @@ package com.asap.server.repository;
 
 import com.asap.server.domain.AvailableDate;
 import com.asap.server.domain.Meeting;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -14,4 +17,8 @@ public interface AvailableDateRepository extends Repository<AvailableDate, Long>
     List<AvailableDate> findByMeeting(final Meeting meeting);
 
     Optional<AvailableDate> findByMeetingAndDate(final Meeting meeting, final LocalDate date);
+
+    @Modifying
+    @Query("delete from AvailableDate a where a.meeting = :meeting")
+    void deleteByMeeting(@Param("meeting") final Meeting meeting);
 }

--- a/src/main/java/com/asap/server/repository/AvailableDateRepository.java
+++ b/src/main/java/com/asap/server/repository/AvailableDateRepository.java
@@ -18,7 +18,7 @@ public interface AvailableDateRepository extends Repository<AvailableDate, Long>
 
     Optional<AvailableDate> findByMeetingAndDate(final Meeting meeting, final LocalDate date);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("delete from AvailableDate a where a.meeting = :meeting")
     void deleteByMeeting(@Param("meeting") final Meeting meeting);
 }

--- a/src/main/java/com/asap/server/repository/PreferTimeRepository.java
+++ b/src/main/java/com/asap/server/repository/PreferTimeRepository.java
@@ -2,7 +2,10 @@ package com.asap.server.repository;
 
 import com.asap.server.domain.Meeting;
 import com.asap.server.domain.PreferTime;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -11,4 +14,9 @@ public interface PreferTimeRepository extends Repository<PreferTime, Long> {
     PreferTime save(final PreferTime preferTime);
 
     List<PreferTime> findByMeeting(final Meeting meeting);
+
+
+    @Modifying
+    @Query("delete from PreferTime p where p.meeting = :meeting")
+    void deleteByMeeting(@Param("meeting") final Meeting meeting);
 }

--- a/src/main/java/com/asap/server/repository/PreferTimeRepository.java
+++ b/src/main/java/com/asap/server/repository/PreferTimeRepository.java
@@ -16,7 +16,7 @@ public interface PreferTimeRepository extends Repository<PreferTime, Long> {
     List<PreferTime> findByMeeting(final Meeting meeting);
 
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("delete from PreferTime p where p.meeting = :meeting")
     void deleteByMeeting(@Param("meeting") final Meeting meeting);
 }

--- a/src/main/java/com/asap/server/repository/TimeBlockRepository.java
+++ b/src/main/java/com/asap/server/repository/TimeBlockRepository.java
@@ -21,7 +21,7 @@ public interface TimeBlockRepository extends Repository<TimeBlock, Long> {
 
     List<TimeBlock> findByAvailableDateIn(final List<AvailableDate> availableDates);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("delete from TimeBlock t where t.availableDate in :availableDates")
     void deleteByAvailableDatesIn(@Param("availableDates") final List<AvailableDate> availableDates);
 }

--- a/src/main/java/com/asap/server/repository/TimeBlockRepository.java
+++ b/src/main/java/com/asap/server/repository/TimeBlockRepository.java
@@ -3,15 +3,25 @@ package com.asap.server.repository;
 import com.asap.server.domain.AvailableDate;
 import com.asap.server.domain.TimeBlock;
 import com.asap.server.domain.enums.TimeSlot;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
 
-import java.util.Optional;
 import java.util.List;
+import java.util.Optional;
 
 public interface TimeBlockRepository extends Repository<TimeBlock, Long> {
 
     void save(final TimeBlock timeBlock);
 
     List<TimeBlock> findByAvailableDate(final AvailableDate availableDate);
+
     Optional<TimeBlock> findByAvailableDateAndTimeSlot(final AvailableDate availableDate, TimeSlot timeSlot);
+
+    List<TimeBlock> findByAvailableDateIn(final List<AvailableDate> availableDates);
+
+    @Modifying
+    @Query("delete from TimeBlock t where t.availableDate in :availableDates")
+    void deleteByAvailableDatesIn(@Param("availableDates") final List<AvailableDate> availableDates);
 }

--- a/src/main/java/com/asap/server/repository/TimeBlockUserRepository.java
+++ b/src/main/java/com/asap/server/repository/TimeBlockUserRepository.java
@@ -3,7 +3,10 @@ package com.asap.server.repository;
 import com.asap.server.domain.TimeBlock;
 import com.asap.server.domain.TimeBlockUser;
 import com.asap.server.domain.User;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -14,4 +17,8 @@ public interface TimeBlockUserRepository extends Repository<TimeBlockUser, Long>
     List<TimeBlockUser> findAllByUser(final User user);
 
     List<TimeBlockUser> findByTimeBlock(final TimeBlock timeBlock);
+
+    @Modifying
+    @Query("delete from TimeBlockUser t where t.timeBlock in :timeblocks")
+    void deleteByTimeBlocksIn(@Param("timeblocks") final List<TimeBlock> timeBlocks);
 }

--- a/src/main/java/com/asap/server/repository/TimeBlockUserRepository.java
+++ b/src/main/java/com/asap/server/repository/TimeBlockUserRepository.java
@@ -18,7 +18,7 @@ public interface TimeBlockUserRepository extends Repository<TimeBlockUser, Long>
 
     List<TimeBlockUser> findByTimeBlock(final TimeBlock timeBlock);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("delete from TimeBlockUser t where t.timeBlock in :timeblocks")
     void deleteByTimeBlocksIn(@Param("timeblocks") final List<TimeBlock> timeBlocks);
 }

--- a/src/main/java/com/asap/server/service/AvailableDateService.java
+++ b/src/main/java/com/asap/server/service/AvailableDateService.java
@@ -6,6 +6,7 @@ import com.asap.server.controller.dto.response.AvailableDatesDto;
 import com.asap.server.controller.dto.response.TimeSlotDto;
 import com.asap.server.domain.AvailableDate;
 import com.asap.server.domain.Meeting;
+import com.asap.server.domain.TimeBlock;
 import com.asap.server.exception.Error;
 import com.asap.server.exception.model.BadRequestException;
 import com.asap.server.exception.model.NotFoundException;
@@ -113,5 +114,14 @@ public class AvailableDateService {
 
     private boolean isDuplicatedDate(final List<String> availableDates) {
         return availableDates.size() != availableDates.stream().distinct().count();
+    }
+
+    public void deleteUserTimes(final Meeting meeting) {
+        List<AvailableDate> availableDates = availableDateRepository.findByMeeting(meeting);
+        List<TimeBlock> timeBlocks = timeBlockService.findByAvailableDateIn(availableDates);
+
+        timeBlockUserService.deleteTimeBlockUsers(timeBlocks);
+        timeBlockService.deleteTimeBlocks(availableDates);
+        availableDateRepository.deleteByMeeting(meeting);
     }
 }

--- a/src/main/java/com/asap/server/service/MeetingService.java
+++ b/src/main/java/com/asap/server/service/MeetingService.java
@@ -108,6 +108,13 @@ public class MeetingService {
         LocalDateTime fixedEndDateTime = LocalDateTime.of(fixedDate, endTime);
 
         meeting.setConfirmedDateTime(fixedStartDateTime, fixedEndDateTime);
+
+        deleteMeetingTimes(meeting);
+    }
+
+    private void deleteMeetingTimes(final Meeting meeting) {
+        availableDateService.deleteUserTimes(meeting);
+        preferTimeService.deletePreferTimes(meeting);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/asap/server/service/PreferTimeService.java
+++ b/src/main/java/com/asap/server/service/PreferTimeService.java
@@ -42,4 +42,8 @@ public class PreferTimeService {
                         .build())
                 .collect(Collectors.toList());
     }
+
+    public void deletePreferTimes(final Meeting meeting) {
+        preferTimeRepository.deleteByMeeting(meeting);
+    }
 }

--- a/src/main/java/com/asap/server/service/TimeBlockService.java
+++ b/src/main/java/com/asap/server/service/TimeBlockService.java
@@ -51,4 +51,12 @@ public class TimeBlockService {
     public List<TimeBlock> getTimeBlocksByAvailableDate(final AvailableDate availableDate) {
         return timeBlockRepository.findByAvailableDate(availableDate);
     }
+
+    public List<TimeBlock> findByAvailableDateIn(final List<AvailableDate> availableDates) {
+        return timeBlockRepository.findByAvailableDateIn(availableDates);
+    }
+
+    public void deleteTimeBlocks(final List<AvailableDate> availableDates) {
+        timeBlockRepository.deleteByAvailableDatesIn(availableDates);
+    }
 }

--- a/src/main/java/com/asap/server/service/TimeBlockUserService.java
+++ b/src/main/java/com/asap/server/service/TimeBlockUserService.java
@@ -47,4 +47,9 @@ public class TimeBlockUserService {
         List<TimeBlockUser> hostTimeBlocks = timeBlockUserRepository.findAllByUser(user);
         return hostTimeBlocks.isEmpty();
     }
+
+    public void deleteTimeBlockUsers(final List<TimeBlock> timeBlocks) {
+        timeBlockUserRepository.deleteByTimeBlocksIn(timeBlocks);
+    }
+
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #208 

## Key Changes 🔑
1. 내용
   - 회의 확정 후 불필요한 데이터 삭제 로직 구현

## To Reviewers 📢
- PreferTime , AvailableDate , TimeBlock, TimeBlockUser 데이터를 삭제했습니다.
