### PR TITLE
#216 [feat] user is_fixed update 로직 개선

### DIFF
--- a/src/main/java/com/asap/server/domain/User.java
+++ b/src/main/java/com/asap/server/domain/User.java
@@ -42,8 +42,4 @@ public class User extends AuditingTimeEntity {
     @Column(nullable = false)
     @Enumerated(value = EnumType.STRING)
     private Role role;
-
-    public void setIsFixed(final Boolean isFixed) {
-        this.isFixed = isFixed;
-    }
 }

--- a/src/main/java/com/asap/server/repository/UserRepository.java
+++ b/src/main/java/com/asap/server/repository/UserRepository.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 public interface UserRepository extends Repository<User, Long> {
     User save(final User user);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("update User u set u.isFixed = true where u.meeting = :meeting and u.id in :userIds")
     void updateUserIsFixedByMeeting(@Param("meeting") final Meeting meeting, @Param("userIds") final List<Long> users);
 

--- a/src/main/java/com/asap/server/repository/UserRepository.java
+++ b/src/main/java/com/asap/server/repository/UserRepository.java
@@ -2,17 +2,26 @@ package com.asap.server.repository;
 
 import com.asap.server.domain.Meeting;
 import com.asap.server.domain.User;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends Repository<User, Long> {
     User save(final User user);
+
+    @Modifying
+    @Query("update User u set u.isFixed = true where u.meeting = :meeting and u.id in :userIds")
+    void updateUserIsFixedByMeeting(@Param("meeting") final Meeting meeting, @Param("userIds") final List<Long> users);
+
     List<User> findByMeetingAndIsFixed(final Meeting meeting, final boolean isFixed);
 
     Optional<User> findById(final Long id);
 
     List<User> findByMeeting(final Meeting meeting);
+
     int countByMeeting(final Meeting meeting);
 }

--- a/src/main/java/com/asap/server/service/MeetingService.java
+++ b/src/main/java/com/asap/server/service/MeetingService.java
@@ -97,7 +97,7 @@ public class MeetingService {
         if (!meeting.authenticateHost(userId))
             throw new UnauthorizedException(INVALID_MEETING_HOST_EXCEPTION);
 
-        userService.setFixedUsers(meetingConfirmRequestDto.getUsers());
+        userService.setFixedUsers(meeting, meetingConfirmRequestDto.getUsers());
 
         LocalDate fixedDate = DateUtil.transformLocalDate(meetingConfirmRequestDto.getMonth(), meetingConfirmRequestDto.getDay());
 

--- a/src/main/java/com/asap/server/service/UserService.java
+++ b/src/main/java/com/asap/server/service/UserService.java
@@ -139,13 +139,12 @@ public class UserService {
                 .collect(Collectors.toList());
     }
 
-    public void setFixedUsers(final List<UserRequestDto> users) {
-        users.forEach(user -> {
-            User fixedUser = userRepository
-                    .findById(user.getId())
-                    .orElseThrow(() -> new NotFoundException(USER_NOT_FOUND_EXCEPTION));
-            fixedUser.setIsFixed(true);
-        });
+    public void setFixedUsers(final Meeting meeting, final List<UserRequestDto> users) {
+        List<Long> userIds = users.stream()
+                .mapToLong(UserRequestDto::getId)
+                .boxed()
+                .collect(Collectors.toList());
+        userRepository.updateUserIsFixedByMeeting(meeting, userIds);
     }
 
     public int getMeetingUserCount(final Meeting meeting) {


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #216 

## Key Changes 🔑
1. 내용
   - user is_fixed update 로직 개선

## To Reviewers 📢
- 이전에는 user 한명 한명 select 를 한뒤 한명 한명 update 를 하는 방식이었습니다. 
그래서 [ (확정된 user의 수) * (2) ] 번의 쿼리가 실행되었습니다.

- 그래서 `in` 명령어를 활용해서 request 로 온 userId 에 포함한 user 만 update 하도록 개선했습니다.
결과적으로 하나의 쿼리만 나가도록 했습니다.

실제로 유저가 10명일 때 회의 확정 속도를 테스트 했을 때 
이전의 방식은 평균 169.2ms 걸렸지만
개선 후 방식은 평균 107.4ms 로 쿼리 속도가 다소 줄어든 것을 확인할 수 있었습니다.
