### PR TITLE
#201 [fix] 회의 가능 시간 중복 입력 예외 처리

### DIFF
--- a/src/main/java/com/asap/server/service/MeetingService.java
+++ b/src/main/java/com/asap/server/service/MeetingService.java
@@ -206,11 +206,5 @@ public class MeetingService {
         List<BestMeetingTimeVo> bestMeetingTimes = bestMeetingUtil.getBestMeetingTime(availableDates, meeting.getDuration(), userCount);
         return BestMeetingTimeResponseDto.of(userCount, bestMeetingTimes);
     }
-
-    private boolean isPreferTimesDuplicated(List<PreferTimeSaveRequestDto> preferTimeSaveRequestDtos) {
-        List<TimeSlot> startTimes = preferTimeSaveRequestDtos.stream()
-                .map(PreferTimeSaveRequestDto::getStartTime)
-                .collect(Collectors.toList());
-        return startTimes.size() != startTimes.stream().distinct().count();
-    }
+    
 }

--- a/src/main/java/com/asap/server/service/MeetingService.java
+++ b/src/main/java/com/asap/server/service/MeetingService.java
@@ -5,7 +5,6 @@ import com.asap.server.common.utils.DateUtil;
 import com.asap.server.config.jwt.JwtService;
 import com.asap.server.controller.dto.request.MeetingConfirmRequestDto;
 import com.asap.server.controller.dto.request.MeetingSaveRequestDto;
-import com.asap.server.controller.dto.request.PreferTimeSaveRequestDto;
 import com.asap.server.controller.dto.response.AvailableDatesDto;
 import com.asap.server.controller.dto.response.BestMeetingTimeResponseDto;
 import com.asap.server.controller.dto.response.FixedMeetingResponseDto;
@@ -18,7 +17,6 @@ import com.asap.server.domain.Meeting;
 import com.asap.server.domain.Place;
 import com.asap.server.domain.User;
 import com.asap.server.domain.enums.Role;
-import com.asap.server.domain.enums.TimeSlot;
 import com.asap.server.exception.Error;
 import com.asap.server.exception.model.ConflictException;
 import com.asap.server.exception.model.ForbiddenException;
@@ -206,5 +204,5 @@ public class MeetingService {
         List<BestMeetingTimeVo> bestMeetingTimes = bestMeetingUtil.getBestMeetingTime(availableDates, meeting.getDuration(), userCount);
         return BestMeetingTimeResponseDto.of(userCount, bestMeetingTimes);
     }
-    
+
 }

--- a/src/main/java/com/asap/server/service/MeetingService.java
+++ b/src/main/java/com/asap/server/service/MeetingService.java
@@ -20,7 +20,6 @@ import com.asap.server.domain.User;
 import com.asap.server.domain.enums.Role;
 import com.asap.server.domain.enums.TimeSlot;
 import com.asap.server.exception.Error;
-import com.asap.server.exception.model.BadRequestException;
 import com.asap.server.exception.model.ConflictException;
 import com.asap.server.exception.model.ForbiddenException;
 import com.asap.server.exception.model.NotFoundException;
@@ -57,9 +56,6 @@ public class MeetingService {
     @Transactional
     public MeetingSaveResponseDto create(final MeetingSaveRequestDto meetingSaveRequestDto) {
         String encryptedPassword = passwordEncoder.encode(meetingSaveRequestDto.getPassword());
-        if (isPreferTimesDuplicated(meetingSaveRequestDto.getPreferTimes())) {
-            throw new BadRequestException(Error.DUPLICATED_TIME_EXCEPTION);
-        }
         Meeting meeting = Meeting.builder()
                 .title(meetingSaveRequestDto.getTitle())
                 .password(encryptedPassword)

--- a/src/main/java/com/asap/server/service/PreferTimeService.java
+++ b/src/main/java/com/asap/server/service/PreferTimeService.java
@@ -4,7 +4,9 @@ import com.asap.server.controller.dto.request.PreferTimeSaveRequestDto;
 import com.asap.server.controller.dto.response.PreferTimeResponseDto;
 import com.asap.server.domain.Meeting;
 import com.asap.server.domain.PreferTime;
+import com.asap.server.domain.enums.TimeSlot;
 import com.asap.server.exception.Error;
+import com.asap.server.exception.model.BadRequestException;
 import com.asap.server.exception.model.NotFoundException;
 import com.asap.server.repository.PreferTimeRepository;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +23,9 @@ public class PreferTimeService {
 
     public void create(final Meeting meeting,
                        final List<PreferTimeSaveRequestDto> saveRequestDtos) {
+        if(isPreferTimeDuplicated(saveRequestDtos)){
+            throw new BadRequestException(Error.DUPLICATED_TIME_EXCEPTION);
+        }
         saveRequestDtos.stream()
                 .sorted(Comparator.comparing(preferTime -> preferTime.getStartTime().getTime()))
                 .map(preferTime -> preferTimeRepository.save(
@@ -45,5 +50,13 @@ public class PreferTimeService {
 
     public void deletePreferTimes(final Meeting meeting) {
         preferTimeRepository.deleteByMeeting(meeting);
+    }
+
+    private boolean isPreferTimeDuplicated(List<PreferTimeSaveRequestDto> requestDtos) {
+        List<TimeSlot> timeSlots = requestDtos.stream()
+                .flatMap(requestDto -> TimeSlot.getTimeSlots(requestDto.getStartTime().ordinal(), requestDto.getEndTime().ordinal()).stream())
+                .collect(Collectors.toList());
+        System.out.println(timeSlots);
+        return timeSlots.size() != timeSlots.stream().distinct().count();
     }
 }

--- a/src/main/java/com/asap/server/service/PreferTimeService.java
+++ b/src/main/java/com/asap/server/service/PreferTimeService.java
@@ -56,7 +56,6 @@ public class PreferTimeService {
         List<TimeSlot> timeSlots = requestDtos.stream()
                 .flatMap(requestDto -> TimeSlot.getTimeSlots(requestDto.getStartTime().ordinal(), requestDto.getEndTime().ordinal()).stream())
                 .collect(Collectors.toList());
-        System.out.println(timeSlots);
         return timeSlots.size() != timeSlots.stream().distinct().count();
     }
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #201 

## Key Changes 🔑
<img width="396" alt="image" src="https://github.com/ASAP-as-soon-as-possible/ASAP_Server/assets/79795051/33d3f49d-f0f1-471c-a507-c22e8b91be4e">


이 부분의 캐시가 화면에 남아있지 않아서 여러 개의 겹치는 시간이 서버에 전송되는 경우를 막아주었습니다.
탭으로 시간을 선택하는 경우에만 발생할 수 있는 에러 같아서 같은 시작 시간대의 저장이 요청된 경우 예외를 던져주는 방식으로 진행했는데 임시방편같아서 썩 맘에 들지는 않네요..

## To Reviewers 📢
-
