### PR TITLE
#221 [fix] 회의 생성 선호시간대 중복 입력 상황 해결

### DIFF
--- a/src/main/java/com/asap/server/service/PreferTimeService.java
+++ b/src/main/java/com/asap/server/service/PreferTimeService.java
@@ -23,7 +23,7 @@ public class PreferTimeService {
 
     public void create(final Meeting meeting,
                        final List<PreferTimeSaveRequestDto> saveRequestDtos) {
-        if(isPreferTimeDuplicated(saveRequestDtos)){
+        if (isPreferTimeDuplicated(saveRequestDtos)) {
             throw new BadRequestException(Error.DUPLICATED_TIME_EXCEPTION);
         }
         saveRequestDtos.stream()
@@ -54,7 +54,7 @@ public class PreferTimeService {
 
     private boolean isPreferTimeDuplicated(List<PreferTimeSaveRequestDto> requestDtos) {
         List<TimeSlot> timeSlots = requestDtos.stream()
-                .flatMap(requestDto -> TimeSlot.getTimeSlots(requestDto.getStartTime().ordinal(), requestDto.getEndTime().ordinal()).stream())
+                .flatMap(requestDto -> TimeSlot.getTimeSlots(requestDto.getStartTime().ordinal(), requestDto.getEndTime().ordinal() - 1).stream())
                 .collect(Collectors.toList());
         return timeSlots.size() != timeSlots.stream().distinct().count();
     }


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #221 

## Key Changes 🔑
1. 회의 생성 선호시간대 중복 입력 상황 해결

## To Reviewers 📢
- 12:00 - 18:00 , 18:00 - 24:00 에서 18:00이 중복시간대로 입력이 되는 것을 확인 못했었네요! 고멘나사이..
