### PR TITLE
#233 [feat] 회의 확정 시 회의 시간 UPDATE 로직 수정

### DIFF
--- a/src/main/java/com/asap/server/controller/dto/request/MeetingConfirmRequestDto.java
+++ b/src/main/java/com/asap/server/controller/dto/request/MeetingConfirmRequestDto.java
@@ -4,11 +4,15 @@ import com.asap.server.domain.enums.TimeSlot;
 import java.util.List;
 import javax.validation.constraints.NotNull;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class MeetingConfirmRequestDto {
     @NotNull(message = "회의 진행 월이 입력되지 않았습니다.")
     private String month;

--- a/src/main/java/com/asap/server/controller/dto/request/UserRequestDto.java
+++ b/src/main/java/com/asap/server/controller/dto/request/UserRequestDto.java
@@ -1,11 +1,15 @@
 package com.asap.server.controller.dto.request;
 
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class UserRequestDto {
     private Long id;
     private String name;

--- a/src/main/java/com/asap/server/domain/Meeting.java
+++ b/src/main/java/com/asap/server/domain/Meeting.java
@@ -22,7 +22,7 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @Builder
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Meeting extends AuditingTimeEntity {
     @Id

--- a/src/main/java/com/asap/server/domain/User.java
+++ b/src/main/java/com/asap/server/domain/User.java
@@ -23,7 +23,7 @@ import javax.persistence.ManyToOne;
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class User extends AuditingTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/asap/server/service/MeetingService.java
+++ b/src/main/java/com/asap/server/service/MeetingService.java
@@ -98,17 +98,17 @@ public class MeetingService {
 
         userService.setFixedUsers(meeting, meetingConfirmRequestDto.getUsers());
 
-        LocalDate fixedDate = DateUtil.transformLocalDate(meetingConfirmRequestDto.getMonth(), meetingConfirmRequestDto.getDay());
+        deleteMeetingTimes(meeting);
 
+        LocalDate fixedDate = DateUtil.transformLocalDate(meetingConfirmRequestDto.getMonth(), meetingConfirmRequestDto.getDay());
         LocalTime startTime = DateUtil.parseLocalTime(meetingConfirmRequestDto.getStartTime().getTime());
         LocalTime endTime = DateUtil.parseLocalTime(meetingConfirmRequestDto.getEndTime().getTime());
 
         LocalDateTime fixedStartDateTime = LocalDateTime.of(fixedDate, startTime);
         LocalDateTime fixedEndDateTime = LocalDateTime.of(fixedDate, endTime);
-
         meeting.setConfirmedDateTime(fixedStartDateTime, fixedEndDateTime);
 
-        deleteMeetingTimes(meeting);
+        meetingRepository.save(meeting);
     }
 
     private void deleteMeetingTimes(final Meeting meeting) {

--- a/src/test/java/com/asap/server/service/meeting/ConfirmMeetingMethodTest.java
+++ b/src/test/java/com/asap/server/service/meeting/ConfirmMeetingMethodTest.java
@@ -9,7 +9,6 @@ import com.asap.server.domain.enums.Duration;
 import com.asap.server.domain.enums.PlaceType;
 import com.asap.server.domain.enums.Role;
 import com.asap.server.domain.enums.TimeSlot;
-import com.asap.server.repository.MeetingRepository;
 import com.asap.server.service.MeetingService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -27,8 +26,6 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 public class ConfirmMeetingMethodTest {
     @Autowired
     private MeetingService meetingService;
-    @Autowired
-    private MeetingRepository meetingRepository;
     @Autowired
     private EntityManager em;
 
@@ -76,7 +73,7 @@ public class ConfirmMeetingMethodTest {
         meetingService.confirmMeeting(body, meeting.getId(), user.getId());
 
         // then
-        final Meeting result = meetingRepository.findById(meeting.getId()).get();
+        final Meeting result = em.find(Meeting.class, meeting.getId());
         assertThat(result.isConfirmedMeeting()).isTrue();
     }
 

--- a/src/test/java/com/asap/server/service/meeting/ConfirmMeetingMethodTest.java
+++ b/src/test/java/com/asap/server/service/meeting/ConfirmMeetingMethodTest.java
@@ -1,0 +1,83 @@
+package com.asap.server.service.meeting;
+
+import com.asap.server.controller.dto.request.MeetingConfirmRequestDto;
+import com.asap.server.controller.dto.request.UserRequestDto;
+import com.asap.server.domain.Meeting;
+import com.asap.server.domain.Place;
+import com.asap.server.domain.User;
+import com.asap.server.domain.enums.Duration;
+import com.asap.server.domain.enums.PlaceType;
+import com.asap.server.domain.enums.Role;
+import com.asap.server.domain.enums.TimeSlot;
+import com.asap.server.repository.MeetingRepository;
+import com.asap.server.service.MeetingService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import javax.persistence.EntityManager;
+import javax.transaction.Transactional;
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@SpringBootTest
+@Transactional
+public class ConfirmMeetingMethodTest {
+    @Autowired
+    private MeetingService meetingService;
+    @Autowired
+    private MeetingRepository meetingRepository;
+    @Autowired
+    private EntityManager em;
+
+    @Test
+    @DisplayName("회의 확정시 ConfirmedDateTime 은 Update 된다.")
+    void setConfirmDateTimeTest() {
+        // given
+        final Place place = Place.builder()
+                .placeType(PlaceType.OFFLINE)
+                .build();
+        final Meeting meeting = Meeting.builder()
+                .title("회의 테스트")
+                .password("0000")
+                .additionalInfo("")
+                .duration(Duration.HALF)
+                .place(place)
+                .build();
+        final User user = User.builder()
+                .meeting(meeting)
+                .name("강원용")
+                .role(Role.HOST)
+                .isFixed(false)
+                .build();
+        meeting.setHost(user);
+
+        em.persist(meeting);
+        em.persist(user);
+        em.flush();
+        em.clear();
+
+        final UserRequestDto userDto = UserRequestDto.builder()
+                .id(user.getId())
+                .name(user.getName())
+                .build();
+        final MeetingConfirmRequestDto body = MeetingConfirmRequestDto.builder()
+                .month("09")
+                .day("07")
+                .dayOfWeek("월")
+                .startTime(TimeSlot.SLOT_6_00)
+                .endTime(TimeSlot.SLOT_6_30)
+                .users(List.of(userDto))
+                .build();
+
+        // when
+        meetingService.confirmMeeting(body, meeting.getId(), user.getId());
+
+        // then
+        final Meeting result = meetingRepository.findById(meeting.getId()).get();
+        assertThat(result.isConfirmedMeeting()).isTrue();
+    }
+
+}


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #233

## Key Changes 🔑
1. 내용
   - 회의 확정 시 회의 시간 UPDATE 로직 수정

## To Reviewers 📢
- `@Modifying(clearAutomatically = true)` 로 인해서 JPQL 실행 후 영속성 컨텍스트가 clear 되는데,
이 때 meeting 도 clear 가 되어서 더티 체킹으로 인한 UPDATE 가 안된 상태였습니다.

- 그래서 save 를 통해서 update 를 하는데, 이로 인해 meeting 을 다시 SELECT 한다는 건 좀 불편하지만...
더 나은 방법이 생각나지 않네요... 😭 

- 로직 수정 보다 테스트 코드 만드는 데 더 오래 걸렸네요... 😅 
