### PR TITLE
#225 [fix] 가독성을 위한 로그 포맷 수정

### DIFF
--- a/src/main/java/com/asap/server/common/aspect/LoggingAspect.java
+++ b/src/main/java/com/asap/server/common/aspect/LoggingAspect.java
@@ -34,13 +34,15 @@ public class LoggingAspect {
         long startAt = System.currentTimeMillis();
         Object returnValue = proceedingJoinPoint.proceed(proceedingJoinPoint.getArgs());
         long endAt = System.currentTimeMillis();
-        log.info("====> Request: {} {} ({}ms)\n *Header = {}\n", request.getMethod(), request.getRequestURL(), endAt - startAt, getHeaders(request));
+        log.info("================================================NEW===============================================");
+        log.info("====> Request: {} {} ({}ms)\n *Header = {}", request.getMethod(), request.getRequestURL(), endAt - startAt, getHeaders(request));
         if ("POST".equalsIgnoreCase(request.getMethod())) {
             log.info("====> Body: {}", objectMapper.readTree(cachingRequest.getContentAsByteArray()));
         }
         if (returnValue != null) {
-            log.info("====> Response: {}\n", returnValue);
+            log.info("====> Response: {}", returnValue);
         }
+        log.info("================================================END===============================================");
         return returnValue;
     }
 

--- a/src/main/java/com/asap/server/common/dto/ErrorDataResponse.java
+++ b/src/main/java/com/asap/server/common/dto/ErrorDataResponse.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 public class ErrorDataResponse<T> extends ErrorResponse {
 
     private T data;
+
     private ErrorDataResponse(int code, String message, T data) {
         super(code, message);
         this.data = data;
@@ -14,5 +15,10 @@ public class ErrorDataResponse<T> extends ErrorResponse {
 
     public static <T> ErrorDataResponse<T> error(Error error, String message, T data) {
         return new ErrorDataResponse<T>(error.getHttpStatusCode(), message, data);
+    }
+
+    @Override
+    public String toString() {
+        return "code: " + super.getCode() + " message: " + super.getMessage() + " data: " + this.data;
     }
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #225 

## Key Changes 🔑
1. 내용
 
![image](https://github.com/ASAP-as-soon-as-possible/ASAP_Server/assets/82709044/165d7464-6d18-47c0-b6da-7048142e0adc)

## To Reviewers 📢
- 로그 보는 데 너무 불편하더라고요... 그래서 포맷 살짝 수정했습니다.
- 또한 error data response 로그가 code, error 만 찍히고 있어서
toString 을 오버라이드 함으로써 data 까지 찍히도록 수정했습니다.
- lombok 의 toString 을 사용하면 error data reponse 내에 있는 data 만 로그에 찍히더라고요..
