### PR TITLE
#227 [feat] [feat] 로그인 시 발생하는 N+1 이슈 해결 및 기타 작업

### DIFF
--- a/src/main/java/com/asap/server/controller/UserController.java
+++ b/src/main/java/com/asap/server/controller/UserController.java
@@ -44,7 +44,7 @@ public class UserController {
     @Operation(summary = "[회의 가능 시간 입력 뷰 - 방장] 방장 가능 시간 입력 API")
     @SecurityRequirement(name = "JWT Auth")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "방장의 회의 가능 시간이 성공적으로 입력되었습니다."),
+            @ApiResponse(responseCode = "201", description = "방장의 회의 가능 시간이 성공적으로 입력되었습니다."),
             @ApiResponse(responseCode = "400",
                     description = "1. 시간 형식이 잘못되었습니다. [YYYY/MM/DD HH:MM]\n"
                             + "2. 중복 입력된 시간이 있습니다.\n"
@@ -70,7 +70,7 @@ public class UserController {
 
     @Operation(summary = "[회의 가능 시간 입력 뷰 - 참여자] 참여자 정보 및 가능 시간 입력 API")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "참여자 회의 가능 시간 입력을 성공하였습니다."),
+            @ApiResponse(responseCode = "201", description = "참여자 회의 가능 시간 입력을 성공하였습니다."),
             @ApiResponse(responseCode = "400",
                     description = "1. 시간 형식이 잘못되었습니다. [YYYY/MM/DD HH:MM]\n"
                             + "2. 중복 입력된 시간이 있습니다.\n"

--- a/src/main/java/com/asap/server/repository/AvailableDateRepository.java
+++ b/src/main/java/com/asap/server/repository/AvailableDateRepository.java
@@ -2,10 +2,7 @@ package com.asap.server.repository;
 
 import com.asap.server.domain.AvailableDate;
 import com.asap.server.domain.Meeting;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
-import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -17,8 +14,4 @@ public interface AvailableDateRepository extends Repository<AvailableDate, Long>
     List<AvailableDate> findByMeeting(final Meeting meeting);
 
     Optional<AvailableDate> findByMeetingAndDate(final Meeting meeting, final LocalDate date);
-
-    @Modifying(clearAutomatically = true)
-    @Query("delete from AvailableDate a where a.meeting = :meeting")
-    void deleteByMeeting(@Param("meeting") final Meeting meeting);
 }

--- a/src/main/java/com/asap/server/repository/MeetingRepository.java
+++ b/src/main/java/com/asap/server/repository/MeetingRepository.java
@@ -13,6 +13,8 @@ public interface MeetingRepository extends Repository<Meeting, Long> {
 
     Meeting save(final Meeting meeting);
 
+    void saveAndFlush(final Meeting meeting);
+
     @EntityGraph(attributePaths = {"host"})
     @Query("select m from Meeting m where m.id = :id")
     Optional<Meeting> findByIdWithHost(@Param("id") final Long id);

--- a/src/main/java/com/asap/server/repository/MeetingRepository.java
+++ b/src/main/java/com/asap/server/repository/MeetingRepository.java
@@ -1,7 +1,10 @@
 package com.asap.server.repository;
 
 import com.asap.server.domain.Meeting;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -9,4 +12,8 @@ public interface MeetingRepository extends Repository<Meeting, Long> {
     Optional<Meeting> findById(final Long id);
 
     Meeting save(final Meeting meeting);
+
+    @EntityGraph(attributePaths = {"host"})
+    @Query("select m from Meeting m where m.id = :id")
+    Optional<Meeting> findByIdWithHost(@Param("id") final Long id);
 }

--- a/src/main/java/com/asap/server/repository/PreferTimeRepository.java
+++ b/src/main/java/com/asap/server/repository/PreferTimeRepository.java
@@ -2,10 +2,7 @@ package com.asap.server.repository;
 
 import com.asap.server.domain.Meeting;
 import com.asap.server.domain.PreferTime;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
-import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -14,9 +11,4 @@ public interface PreferTimeRepository extends Repository<PreferTime, Long> {
     PreferTime save(final PreferTime preferTime);
 
     List<PreferTime> findByMeeting(final Meeting meeting);
-
-
-    @Modifying(clearAutomatically = true)
-    @Query("delete from PreferTime p where p.meeting = :meeting")
-    void deleteByMeeting(@Param("meeting") final Meeting meeting);
 }

--- a/src/main/java/com/asap/server/repository/TimeBlockRepository.java
+++ b/src/main/java/com/asap/server/repository/TimeBlockRepository.java
@@ -3,10 +3,7 @@ package com.asap.server.repository;
 import com.asap.server.domain.AvailableDate;
 import com.asap.server.domain.TimeBlock;
 import com.asap.server.domain.enums.TimeSlot;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
-import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -18,10 +15,4 @@ public interface TimeBlockRepository extends Repository<TimeBlock, Long> {
     List<TimeBlock> findByAvailableDate(final AvailableDate availableDate);
 
     Optional<TimeBlock> findByAvailableDateAndTimeSlot(final AvailableDate availableDate, TimeSlot timeSlot);
-
-    List<TimeBlock> findByAvailableDateIn(final List<AvailableDate> availableDates);
-
-    @Modifying(clearAutomatically = true)
-    @Query("delete from TimeBlock t where t.availableDate in :availableDates")
-    void deleteByAvailableDatesIn(@Param("availableDates") final List<AvailableDate> availableDates);
 }

--- a/src/main/java/com/asap/server/repository/TimeBlockUserRepository.java
+++ b/src/main/java/com/asap/server/repository/TimeBlockUserRepository.java
@@ -17,8 +17,4 @@ public interface TimeBlockUserRepository extends Repository<TimeBlockUser, Long>
     List<TimeBlockUser> findAllByUser(final User user);
 
     List<TimeBlockUser> findByTimeBlock(final TimeBlock timeBlock);
-
-    @Modifying(clearAutomatically = true)
-    @Query("delete from TimeBlockUser t where t.timeBlock in :timeblocks")
-    void deleteByTimeBlocksIn(@Param("timeblocks") final List<TimeBlock> timeBlocks);
 }

--- a/src/main/java/com/asap/server/service/AvailableDateService.java
+++ b/src/main/java/com/asap/server/service/AvailableDateService.java
@@ -6,7 +6,6 @@ import com.asap.server.controller.dto.response.AvailableDatesDto;
 import com.asap.server.controller.dto.response.TimeSlotDto;
 import com.asap.server.domain.AvailableDate;
 import com.asap.server.domain.Meeting;
-import com.asap.server.domain.TimeBlock;
 import com.asap.server.exception.Error;
 import com.asap.server.exception.model.BadRequestException;
 import com.asap.server.exception.model.NotFoundException;
@@ -114,14 +113,5 @@ public class AvailableDateService {
 
     private boolean isDuplicatedDate(final List<String> availableDates) {
         return availableDates.size() != availableDates.stream().distinct().count();
-    }
-
-    public void deleteUserTimes(final Meeting meeting) {
-        List<AvailableDate> availableDates = availableDateRepository.findByMeeting(meeting);
-        List<TimeBlock> timeBlocks = timeBlockService.findByAvailableDateIn(availableDates);
-
-        timeBlockUserService.deleteTimeBlockUsers(timeBlocks);
-        timeBlockService.deleteTimeBlocks(availableDates);
-        availableDateRepository.deleteByMeeting(meeting);
     }
 }

--- a/src/main/java/com/asap/server/service/MeetingService.java
+++ b/src/main/java/com/asap/server/service/MeetingService.java
@@ -96,8 +96,6 @@ public class MeetingService {
         if (!meeting.authenticateHost(userId))
             throw new UnauthorizedException(INVALID_MEETING_HOST_EXCEPTION);
 
-        userService.setFixedUsers(meeting, meetingConfirmRequestDto.getUsers());
-
         LocalDate fixedDate = DateUtil.transformLocalDate(meetingConfirmRequestDto.getMonth(), meetingConfirmRequestDto.getDay());
         LocalTime startTime = DateUtil.parseLocalTime(meetingConfirmRequestDto.getStartTime().getTime());
         LocalTime endTime = DateUtil.parseLocalTime(meetingConfirmRequestDto.getEndTime().getTime());
@@ -106,7 +104,9 @@ public class MeetingService {
         LocalDateTime fixedEndDateTime = LocalDateTime.of(fixedDate, endTime);
         meeting.setConfirmedDateTime(fixedStartDateTime, fixedEndDateTime);
 
-        meetingRepository.save(meeting);
+        meetingRepository.saveAndFlush(meeting);
+
+        userService.setFixedUsers(meeting, meetingConfirmRequestDto.getUsers());
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/asap/server/service/MeetingService.java
+++ b/src/main/java/com/asap/server/service/MeetingService.java
@@ -98,8 +98,6 @@ public class MeetingService {
 
         userService.setFixedUsers(meeting, meetingConfirmRequestDto.getUsers());
 
-        deleteMeetingTimes(meeting);
-
         LocalDate fixedDate = DateUtil.transformLocalDate(meetingConfirmRequestDto.getMonth(), meetingConfirmRequestDto.getDay());
         LocalTime startTime = DateUtil.parseLocalTime(meetingConfirmRequestDto.getStartTime().getTime());
         LocalTime endTime = DateUtil.parseLocalTime(meetingConfirmRequestDto.getEndTime().getTime());
@@ -109,11 +107,6 @@ public class MeetingService {
         meeting.setConfirmedDateTime(fixedStartDateTime, fixedEndDateTime);
 
         meetingRepository.save(meeting);
-    }
-
-    private void deleteMeetingTimes(final Meeting meeting) {
-        availableDateService.deleteUserTimes(meeting);
-        preferTimeService.deletePreferTimes(meeting);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/asap/server/service/PreferTimeService.java
+++ b/src/main/java/com/asap/server/service/PreferTimeService.java
@@ -48,10 +48,6 @@ public class PreferTimeService {
                 .collect(Collectors.toList());
     }
 
-    public void deletePreferTimes(final Meeting meeting) {
-        preferTimeRepository.deleteByMeeting(meeting);
-    }
-
     private boolean isPreferTimeDuplicated(List<PreferTimeSaveRequestDto> requestDtos) {
         List<TimeSlot> timeSlots = requestDtos.stream()
                 .flatMap(requestDto -> TimeSlot.getTimeSlots(requestDto.getStartTime().ordinal(), requestDto.getEndTime().ordinal() - 1).stream())

--- a/src/main/java/com/asap/server/service/TimeBlockService.java
+++ b/src/main/java/com/asap/server/service/TimeBlockService.java
@@ -51,12 +51,4 @@ public class TimeBlockService {
     public List<TimeBlock> getTimeBlocksByAvailableDate(final AvailableDate availableDate) {
         return timeBlockRepository.findByAvailableDate(availableDate);
     }
-
-    public List<TimeBlock> findByAvailableDateIn(final List<AvailableDate> availableDates) {
-        return timeBlockRepository.findByAvailableDateIn(availableDates);
-    }
-
-    public void deleteTimeBlocks(final List<AvailableDate> availableDates) {
-        timeBlockRepository.deleteByAvailableDatesIn(availableDates);
-    }
 }

--- a/src/main/java/com/asap/server/service/TimeBlockUserService.java
+++ b/src/main/java/com/asap/server/service/TimeBlockUserService.java
@@ -48,8 +48,4 @@ public class TimeBlockUserService {
         return hostTimeBlocks.isEmpty();
     }
 
-    public void deleteTimeBlockUsers(final List<TimeBlock> timeBlocks) {
-        timeBlockUserRepository.deleteByTimeBlocksIn(timeBlocks);
-    }
-
 }

--- a/src/main/java/com/asap/server/service/UserService.java
+++ b/src/main/java/com/asap/server/service/UserService.java
@@ -156,7 +156,7 @@ public class UserService {
             final Long meetingId,
             final HostLoginRequestDto requestDto
     ) {
-        Meeting meeting = meetingRepository.findById(meetingId)
+        Meeting meeting = meetingRepository.findByIdWithHost(meetingId)
                 .orElseThrow(() -> new NotFoundException(Error.MEETING_NOT_FOUND_EXCEPTION));
 
         if (!meeting.checkHostName(requestDto.getName()))


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #227 

## Key Changes 🔑
**1. 로그인 시 발생하는 N+1 이슈**
지금까지 로그인을 했을 때 아래와 같은 플로우로 실행되었습니다.
```java
         // 1. 회의 시간 조회
         Meeting meeting = meetingRepository.findByIdWithHost(meetingId)
                .orElseThrow(() -> new NotFoundException(Error.MEETING_NOT_FOUND_EXCEPTION));
        // 2. 방장 조회
        if (!meeting.checkHostName(requestDto.getName()))
            throw new UnauthorizedException(Error.INVALID_HOST_ID_PASSWORD_EXCEPTION);
        // 3. 시간을 입력했는지 조회
        if (timeBlockUserService.isEmptyHostTimeBlock(meeting.getHost())) {
            throw new HostTimeForbiddenException(Error.HOST_MEETING_TIME_NOT_PROVIDED, responseDto);
        }
```
host 의 fetchType 이 LAZY이기 때문에 
`meeting.checkHostName(requestDto.getName())` 을 실행했을 때 SELECT 쿼리가 추가로 실행되기 때문에
N+1 이슈가 발생하고 있습니다.
그래서 fetch join 을 통해서 로그인 화면에서 회의를 불러올 때에는 host 정보까지 한번에 불어오도록 함으로써
N+1 이슈를 해결했습니다.
결과 : 3번의 쿼리 -> 2번의 쿼리

**2. 불필요한 데이터 삭제 로직 롤백**
DB도 아직까지 저장 공간 괜찮고.. 추후 데이터 분석을 위해서 데이터 삭제 로직을 롤백했습니다.

**3. 회의 확정 이후 save 후 바로 flush**
회의 확정 이후 `setFixedUsers` 로 인한 영속성 컨텍스트 초기화 이전에 
회의를 확정한 것을 flush 하게끔 만들었습니다.
영속성 컨텍스트 초기화로 인한 meeting 을 재조회하는 것을 막았습니다.

**4. swagger 문서 수정**
동헌이가 슬랙에서 말했던 201 수정했습니다.

## To Reviewers 📢
1번 관련해서
`@EntityGraph` 와 `@Query` 를 같이 사용한 이유는
`@EntityGraph` 를 사용했을 때, 우선 `findById` 메서드가 오버 로딩 할 수 없었고
다른 곳에서도 기존의 `findById` 메서드를 사용하는데, 다른 곳에서는 host 를 지연 로딩해도 되기 때문에
`@EntityGraph` 와 `@Query` 를 같이 사용해서 새로운 함수를 만들었습니다.

또한 `@EntityGraph` 를 사용하면 OUTER JOIN 으로 JOIN이 되는데,
Meeting 과 Host 는 1:1 매핑이기 때문에 OUTER JOIN 을 해도 데이터가 한 개만 존재하기 때문에
OUTER JOIN을 해도 상관없겠다고 판단해서 `@EntityGraph` 으로 Fetch Join 을 했습니다.
