### PR TITLE
#242 [feat] appender 수정 및 info , error 로깅 분리

### DIFF
--- a/src/main/java/com/asap/server/common/advice/ControllerExceptionAdvice.java
+++ b/src/main/java/com/asap/server/common/advice/ControllerExceptionAdvice.java
@@ -139,6 +139,7 @@ public class ControllerExceptionAdvice {
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(Exception.class)
     protected ErrorResponse handleException(final Exception error, final HttpServletRequest request) throws IOException {
+        log.error("================================================NEW===============================================");
         log.error(error.getMessage(), error);
         slackUtil.sendAlert(error, request);
         return ErrorResponse.error(Error.INTERNAL_SERVER_ERROR);

--- a/src/main/resources/file-error-appender.xml
+++ b/src/main/resources/file-error-appender.xml
@@ -1,7 +1,8 @@
 <included>
-    <appender name="FILE-ERROR" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <appender name="FILE-ERROR" class="ch.qos.logback.core.FileAppender">
         <file>/home/ubuntu/app/logs/error/error-${BY_DATE}.log</file>
-        <filter class = "ch.qos.logback.classic.filter.LevelFilter">
+        <append>true</append>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>ERROR</level>
             <onMatch>ACCEPT</onMatch>
             <onMismatch>DENY</onMismatch>
@@ -9,11 +10,5 @@
         <encoder>
             <pattern>${LOG_PATTERN}</pattern>
         </encoder>
-        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern> /home/ubuntu/app/logs/error/error-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
-            <maxHistory>30</maxHistory>
-            <totalSizeCap>3GB</totalSizeCap>
-            <maxFileSize>10MB</maxFileSize>
-        </rollingPolicy>
     </appender>
 </included>

--- a/src/main/resources/file-info-appender.xml
+++ b/src/main/resources/file-info-appender.xml
@@ -1,7 +1,8 @@
 <included>
-    <appender name="FILE-INFO" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <appender name="FILE-INFO" class="ch.qos.logback.core.FileAppender">
         <file>/home/ubuntu/app/logs/info/info-${BY_DATE}.log</file>
-        <filter class = "ch.qos.logback.classic.filter.LevelFilter">
+        <append>true</append>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>INFO</level>
             <onMatch>ACCEPT</onMatch>
             <onMismatch>DENY</onMismatch>
@@ -9,11 +10,5 @@
         <encoder>
             <pattern>${LOG_PATTERN}</pattern>
         </encoder>
-        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern> /home/ubuntu/app/logs/info/info-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
-            <maxHistory>30</maxHistory>
-            <totalSizeCap>3GB</totalSizeCap>
-            <maxFileSize>10MB</maxFileSize>
-        </rollingPolicy>
     </appender>
 </included>


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #242 

## Key Changes 🔑
1. 내용
   - appender 수정 및 info , error 로깅 분리

## To Reviewers 📢
- 지금까지 error 내역은 error 파일에 error 를 일으켰던 요청의 헤더 값과 바디 값은 info 파일에 저장되었는데,
error 발생 시 error 파일 내에 body, header, 에러 값들이 같이 표시되면 에러를 확인하기 더 편할 것이라 생각해서 
info 레벨과 error 레벨을 분리했습니다.

![image](https://github.com/ASAP-as-soon-as-possible/ASAP_Server/assets/82709044/f3e276c0-a1cc-42c3-ac6d-c6a2c3888763)


- 하나의 파일로 로깅이 안되는 문제도 있고, 아래 사진과 같이 [공식 문서](https://logback.qos.ch/manual/appenders.html#SizeAndTimeBasedRollingPolicy)에서 비추천한다길래 file appender로 바꿨습니다.
![image](https://github.com/ASAP-as-soon-as-possible/ASAP_Server/assets/82709044/c6183aff-2d88-4513-914c-c2b2fdbcc861)

