### PR TITLE
#245 [feat] 최적의 회의 시간 알고리즘 QueryDsl로 마이그레이션

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     implementation 'mysql:mysql-connector-java:8.0.32'
 
     // SWAGGER
-    implementation 'org.springdoc:springdoc-openapi-ui:1.7.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 
     // Jwt Token
     implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'

--- a/src/main/java/com/asap/server/common/utils/BestMeetingUtil.java
+++ b/src/main/java/com/asap/server/common/utils/BestMeetingUtil.java
@@ -62,7 +62,7 @@ public class BestMeetingUtil {
 
     private List<BestMeetingTimeVo> findTop3BestMeetingTimesSortByWeight(final List<BestMeetingTimeVo> bestMeetingTimes) {
         return bestMeetingTimes.stream()
-                .sorted(Comparator.comparing(BestMeetingTimeVo::getWeight, Comparator.reverseOrder()))
+                .sorted(Comparator.comparing(BestMeetingTimeVo::weight, Comparator.reverseOrder()))
                 .limit(BEST_MEETING_TIME_SIZE)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/asap/server/common/utils/strategy/impl/FindBestMeetingTimeStrategyImpl.java
+++ b/src/main/java/com/asap/server/common/utils/strategy/impl/FindBestMeetingTimeStrategyImpl.java
@@ -7,7 +7,6 @@ import com.asap.server.service.vo.TimeBlockVo;
 import com.asap.server.service.vo.TimeBlocksByDateVo;
 import org.springframework.stereotype.Component;
 
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -17,10 +16,10 @@ public class FindBestMeetingTimeStrategyImpl implements FindBestMeetingTimeStrat
     @Override
     public List<BestMeetingTimeVo> find(final TimeBlocksByDateVo timeBlocksByDate, final int needTimeBlockCount, final int userCount) {
         List<TimeBlockVo> sortedTimeBlocks = filterByUserCountAndSortByTime(timeBlocksByDate.getTimeBlocks(), userCount);
-        return findBestMeetingTime(sortedTimeBlocks, timeBlocksByDate.getDate(), needTimeBlockCount);
+        return findBestMeetingTime(sortedTimeBlocks, timeBlocksByDate, needTimeBlockCount);
     }
 
-    private List<BestMeetingTimeVo> findBestMeetingTime(final List<TimeBlockVo> timeBlocks, final LocalDate date, final int needTimeBlockCount) {
+    private List<BestMeetingTimeVo> findBestMeetingTime(final List<TimeBlockVo> timeBlocks, final TimeBlocksByDateVo timeBlocksByDate, final int needTimeBlockCount) {
         List<BestMeetingTimeVo> bestMeetingTimes = new ArrayList<>();
 
         int endIndex = timeBlocks.size() - needTimeBlockCount + 1;
@@ -32,7 +31,7 @@ public class FindBestMeetingTimeStrategyImpl implements FindBestMeetingTimeStrat
 
             BestMeetingTimeVo bestMeetingTime = getBestMeetingTime(
                     timeBlocks,
-                    date,
+                    timeBlocksByDate,
                     timeBlockIdx,
                     needTimeBlockCount,
                     sumWeight
@@ -71,7 +70,7 @@ public class FindBestMeetingTimeStrategyImpl implements FindBestMeetingTimeStrat
 
     private BestMeetingTimeVo getBestMeetingTime(
             final List<TimeBlockVo> timeBlocks,
-            final LocalDate date,
+            final TimeBlocksByDateVo timeBlocksByDate,
             final int timeBlockIdx,
             final int needTimeBlockCount,
             final int sumWeight
@@ -80,7 +79,8 @@ public class FindBestMeetingTimeStrategyImpl implements FindBestMeetingTimeStrat
         TimeSlot endTime = TimeSlot.getTimeSlot(startTime.ordinal() + needTimeBlockCount);
 
         return new BestMeetingTimeVo(
-                date,
+                timeBlocksByDate.getId(),
+                timeBlocksByDate.getDate(),
                 startTime,
                 endTime,
                 sumWeight

--- a/src/main/java/com/asap/server/common/utils/strategy/impl/FindBestMeetingTimeStrategyImpl.java
+++ b/src/main/java/com/asap/server/common/utils/strategy/impl/FindBestMeetingTimeStrategyImpl.java
@@ -5,7 +5,6 @@ import com.asap.server.domain.enums.TimeSlot;
 import com.asap.server.service.vo.BestMeetingTimeVo;
 import com.asap.server.service.vo.TimeBlockVo;
 import com.asap.server.service.vo.TimeBlocksByDateVo;
-import com.asap.server.service.vo.UserVo;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
@@ -46,18 +45,18 @@ public class FindBestMeetingTimeStrategyImpl implements FindBestMeetingTimeStrat
 
     private List<TimeBlockVo> filterByUserCountAndSortByTime(final List<TimeBlockVo> timeBlocks, final int userCount) {
         return timeBlocks.stream()
-                .filter(timeBlockVo -> timeBlockVo.getUsers().size() == userCount)
+                .filter(timeBlockVo -> timeBlockVo.userCount() == userCount)
                 .sorted(TimeBlockVo::compareTo)
                 .collect(Collectors.toList());
     }
 
     private boolean isBestMeetingTime(final List<TimeBlockVo> timeBlocks, final int timeBlockIdx, final int endIdx) {
         boolean isBestMeetingTime = true;
-        TimeSlot nextTime = timeBlocks.get(timeBlockIdx).getTimeSlot();
+        TimeSlot nextTime = timeBlocks.get(timeBlockIdx).timeSlot();
         for (int i = timeBlockIdx + 1; i < endIdx; i++) {
-            if (nextTime.ordinal() + 1 != timeBlocks.get(i).getTimeSlot().ordinal()) return false;
+            if (nextTime.ordinal() + 1 != timeBlocks.get(i).timeSlot().ordinal()) return false;
 
-            nextTime = timeBlocks.get(i).getTimeSlot();
+            nextTime = timeBlocks.get(i).timeSlot();
         }
         return isBestMeetingTime;
     }
@@ -66,7 +65,7 @@ public class FindBestMeetingTimeStrategyImpl implements FindBestMeetingTimeStrat
         return timeBlocks
                 .subList(startIdx, endIdx)
                 .stream()
-                .map(TimeBlockVo::getWeight)
+                .map(TimeBlockVo::weight)
                 .reduce(0, Integer::sum);
     }
 
@@ -77,15 +76,13 @@ public class FindBestMeetingTimeStrategyImpl implements FindBestMeetingTimeStrat
             final int needTimeBlockCount,
             final int sumWeight
     ) {
-        TimeSlot startTime = timeBlocks.get(timeBlockIdx).getTimeSlot();
+        TimeSlot startTime = timeBlocks.get(timeBlockIdx).timeSlot();
         TimeSlot endTime = TimeSlot.getTimeSlot(startTime.ordinal() + needTimeBlockCount);
-        List<UserVo> users = timeBlocks.get(timeBlockIdx).getUsers();
 
         return new BestMeetingTimeVo(
                 date,
                 startTime,
                 endTime,
-                users,
                 sumWeight
         );
     }

--- a/src/main/java/com/asap/server/controller/dto/response/BestMeetingTimeResponseDto.java
+++ b/src/main/java/com/asap/server/controller/dto/response/BestMeetingTimeResponseDto.java
@@ -1,6 +1,7 @@
 package com.asap.server.controller.dto.response;
 
 import com.asap.server.service.vo.BestMeetingTimeVo;
+import com.asap.server.service.vo.BestMeetingTimeWithUsersVo;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
@@ -20,7 +21,7 @@ public class BestMeetingTimeResponseDto {
     private static final int SECOND_BEST_MEETING_INDEX = 1;
     private static final int THIRD_BEST_MEETING_INDEX = 2;
 
-    public static BestMeetingTimeResponseDto of(int memberCount, List<BestMeetingTimeVo> bestMeetingTimes) {
+    public static BestMeetingTimeResponseDto of(int memberCount, List<BestMeetingTimeWithUsersVo> bestMeetingTimes) {
         return new BestMeetingTimeResponseDto(
                 memberCount,
                 MeetingTimeResponseDto.of(bestMeetingTimes.get(FIRST_BEST_MEETING_INDEX)),

--- a/src/main/java/com/asap/server/controller/dto/response/MeetingTimeResponseDto.java
+++ b/src/main/java/com/asap/server/controller/dto/response/MeetingTimeResponseDto.java
@@ -2,7 +2,7 @@ package com.asap.server.controller.dto.response;
 
 import com.asap.server.common.utils.DateUtil;
 import com.asap.server.service.vo.AvailableMeetingTimeVo;
-import com.asap.server.service.vo.BestMeetingTimeVo;
+import com.asap.server.service.vo.BestMeetingTimeWithUsersVo;
 import com.asap.server.service.vo.UserVo;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -21,30 +21,15 @@ public class MeetingTimeResponseDto {
     private String endTime;
     private List<UserVo> users;
 
-    public static MeetingTimeResponseDto of(AvailableMeetingTimeVo availableMeetingTime) {
-        if (availableMeetingTime == null) return null;
-        String month = Integer.valueOf(availableMeetingTime.getDate().substring(0, 2)).toString();
-        String day = Integer.valueOf(availableMeetingTime.getDate().substring(3, 5)).toString();
-        String dayOfWeek = availableMeetingTime.getDate().substring(6, 7);
-        return new MeetingTimeResponseDto(
-                month,
-                day,
-                dayOfWeek,
-                availableMeetingTime.getStartTime().getTime(),
-                availableMeetingTime.getEndTime().getTime(),
-                availableMeetingTime.getUsers()
-        );
-    }
-
-    public static MeetingTimeResponseDto of(BestMeetingTimeVo bestMeetingTime) {
+    public static MeetingTimeResponseDto of(BestMeetingTimeWithUsersVo bestMeetingTime) {
         if (bestMeetingTime == null) return null;
         return new MeetingTimeResponseDto(
-                DateUtil.getMonth(bestMeetingTime.getDate()),
-                DateUtil.getDay(bestMeetingTime.getDate()),
-                DateUtil.getDayOfWeek(bestMeetingTime.getDate()),
-                bestMeetingTime.getStartTime().getTime(),
-                bestMeetingTime.getEndTime().getTime(),
-                bestMeetingTime.getUsers()
+                DateUtil.getMonth(bestMeetingTime.date()),
+                DateUtil.getDay(bestMeetingTime.date()),
+                DateUtil.getDayOfWeek(bestMeetingTime.date()),
+                bestMeetingTime.startTime().getTime(),
+                bestMeetingTime.endTime().getTime(),
+                bestMeetingTime.users()
         );
     }
 }

--- a/src/main/java/com/asap/server/repository/TimeBlockUserRepository.java
+++ b/src/main/java/com/asap/server/repository/TimeBlockUserRepository.java
@@ -3,10 +3,7 @@ package com.asap.server.repository;
 import com.asap.server.domain.TimeBlock;
 import com.asap.server.domain.TimeBlockUser;
 import com.asap.server.domain.User;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
-import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 

--- a/src/main/java/com/asap/server/repository/timeblock/TimeBlockRepository.java
+++ b/src/main/java/com/asap/server/repository/timeblock/TimeBlockRepository.java
@@ -1,4 +1,4 @@
-package com.asap.server.repository;
+package com.asap.server.repository.timeblock;
 
 import com.asap.server.domain.AvailableDate;
 import com.asap.server.domain.TimeBlock;
@@ -8,7 +8,7 @@ import org.springframework.data.repository.Repository;
 import java.util.List;
 import java.util.Optional;
 
-public interface TimeBlockRepository extends Repository<TimeBlock, Long> {
+public interface TimeBlockRepository extends Repository<TimeBlock, Long>, TimeBlockRepositoryCustom {
 
     void save(final TimeBlock timeBlock);
 

--- a/src/main/java/com/asap/server/repository/timeblock/TimeBlockRepositoryCustom.java
+++ b/src/main/java/com/asap/server/repository/timeblock/TimeBlockRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.asap.server.repository.timeblock;
+
+import com.asap.server.service.vo.TimeBlockVo;
+
+import java.util.List;
+
+public interface TimeBlockRepositoryCustom {
+    List<TimeBlockVo> findByAvailableDate(final Long availableId);
+}

--- a/src/main/java/com/asap/server/repository/timeblock/TimeBlockRepositoryImpl.java
+++ b/src/main/java/com/asap/server/repository/timeblock/TimeBlockRepositoryImpl.java
@@ -1,0 +1,34 @@
+package com.asap.server.repository.timeblock;
+
+import com.asap.server.service.vo.QTimeBlockVo;
+import com.asap.server.service.vo.TimeBlockVo;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+import static com.asap.server.domain.QTimeBlock.timeBlock;
+import static com.asap.server.domain.QTimeBlockUser.timeBlockUser;
+import static com.asap.server.domain.QUser.user;
+
+@RequiredArgsConstructor
+public class TimeBlockRepositoryImpl implements TimeBlockRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<TimeBlockVo> findByAvailableDate(Long availableId) {
+        return queryFactory.select(new QTimeBlockVo(
+                        timeBlock.weight.min().as("weight"),
+                        timeBlock.timeSlot.as("timeSlot"),
+                        user.id.count().as("userCount")
+                ))
+                .from(timeBlockUser)
+                .innerJoin(timeBlock).on(
+                        timeBlockUser.timeBlock.id.eq(timeBlock.id)
+                                .and(timeBlock.availableDate.id.eq(availableId))
+                )
+                .innerJoin(user).on(timeBlockUser.user.id.eq(user.id))
+                .groupBy(timeBlock.timeSlot)
+                .fetch();
+    }
+}

--- a/src/main/java/com/asap/server/repository/user/UserRepositoryCustom.java
+++ b/src/main/java/com/asap/server/repository/user/UserRepositoryCustom.java
@@ -1,10 +1,13 @@
 package com.asap.server.repository.user;
 
 import com.asap.server.domain.Meeting;
-import com.asap.server.domain.User;
+import com.asap.server.domain.enums.TimeSlot;
+import com.asap.server.service.vo.UserVo;
 
 import java.util.List;
 
 public interface UserRepositoryCustom {
     void updateUserIsFixedByMeeting(final Meeting meeting, final List<Long> users);
+
+    List<UserVo> findByAvailableDateAndTimeSlots(Long availableDateId, List<TimeSlot> timeSlots);
 }

--- a/src/main/java/com/asap/server/repository/user/UserRepositoryImpl.java
+++ b/src/main/java/com/asap/server/repository/user/UserRepositoryImpl.java
@@ -1,11 +1,16 @@
 package com.asap.server.repository.user;
 
 import com.asap.server.domain.Meeting;
+import com.asap.server.domain.enums.TimeSlot;
+import com.asap.server.service.vo.QUserVo;
+import com.asap.server.service.vo.UserVo;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 
+import static com.asap.server.domain.QTimeBlock.timeBlock;
+import static com.asap.server.domain.QTimeBlockUser.timeBlockUser;
 import static com.asap.server.domain.QUser.user;
 
 @RequiredArgsConstructor
@@ -21,5 +26,20 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
                                 .and(user.id.in(users))
                 )
                 .execute();
+    }
+
+    @Override
+    public List<UserVo> findByAvailableDateAndTimeSlots(Long availableDateId, List<TimeSlot> timeSlots) {
+        return queryFactory.select(new QUserVo(
+                        user.id,
+                        user.name)
+                )
+                .from(timeBlockUser)
+                .innerJoin(timeBlock).on(timeBlockUser.timeBlock.id.eq(timeBlock.id)
+                        .and(timeBlock.availableDate.id.eq(availableDateId))
+                        .and(timeBlock.timeSlot.in(timeSlots)))
+                .innerJoin(user).on(timeBlockUser.user.id.eq(user.id))
+                .groupBy(user.id)
+                .fetch();
     }
 }

--- a/src/main/java/com/asap/server/service/AvailableDateService.java
+++ b/src/main/java/com/asap/server/service/AvailableDateService.java
@@ -81,10 +81,7 @@ public class AvailableDateService {
         return availableDates.stream()
                 .map(availableDate -> {
                     List<TimeBlockVo> timeBlocks = timeBlockService
-                            .getTimeBlocksByAvailableDate(availableDate)
-                            .stream()
-                            .map(TimeBlockVo::of)
-                            .collect(Collectors.toList());
+                            .getTimeBlocksByAvailableDate(availableDate.getId());
 
                     return TimeBlocksByDateVo.of(availableDate, timeBlocks);
                 }).collect(Collectors.toList());

--- a/src/main/java/com/asap/server/service/MeetingService.java
+++ b/src/main/java/com/asap/server/service/MeetingService.java
@@ -24,6 +24,7 @@ import com.asap.server.exception.model.NotFoundException;
 import com.asap.server.exception.model.UnauthorizedException;
 import com.asap.server.repository.meeting.MeetingRepository;
 import com.asap.server.service.vo.BestMeetingTimeVo;
+import com.asap.server.service.vo.BestMeetingTimeWithUsersVo;
 import com.asap.server.service.vo.TimeBlocksByDateVo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -197,7 +198,8 @@ public class MeetingService {
         List<TimeBlocksByDateVo> availableDates = availableDateService.getAvailableDateVos(meeting);
 
         List<BestMeetingTimeVo> bestMeetingTimes = bestMeetingUtil.getBestMeetingTime(availableDates, meeting.getDuration(), userCount);
-        return BestMeetingTimeResponseDto.of(userCount, bestMeetingTimes);
+        List<BestMeetingTimeWithUsersVo> bestMeetingTimeWithUsers = userService.getBestMeetingInUsers(bestMeetingTimes);
+        return BestMeetingTimeResponseDto.of(userCount, bestMeetingTimeWithUsers);
     }
 
 }

--- a/src/main/java/com/asap/server/service/TimeBlockService.java
+++ b/src/main/java/com/asap/server/service/TimeBlockService.java
@@ -6,7 +6,8 @@ import com.asap.server.domain.TimeBlock;
 import com.asap.server.domain.enums.TimeSlot;
 import com.asap.server.exception.Error;
 import com.asap.server.exception.model.NotFoundException;
-import com.asap.server.repository.TimeBlockRepository;
+import com.asap.server.repository.timeblock.TimeBlockRepository;
+import com.asap.server.service.vo.TimeBlockVo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -50,5 +51,9 @@ public class TimeBlockService {
 
     public List<TimeBlock> getTimeBlocksByAvailableDate(final AvailableDate availableDate) {
         return timeBlockRepository.findByAvailableDate(availableDate);
+    }
+
+    public List<TimeBlockVo> getTimeBlocksByAvailableDate(final Long availableDateId) {
+        return timeBlockRepository.findByAvailableDate(availableDateId);
     }
 }

--- a/src/main/java/com/asap/server/service/UserService.java
+++ b/src/main/java/com/asap/server/service/UserService.java
@@ -21,6 +21,9 @@ import com.asap.server.exception.model.NotFoundException;
 import com.asap.server.exception.model.UnauthorizedException;
 import com.asap.server.repository.meeting.MeetingRepository;
 import com.asap.server.repository.user.UserRepository;
+import com.asap.server.service.vo.BestMeetingTimeVo;
+import com.asap.server.service.vo.BestMeetingTimeWithUsersVo;
+import com.asap.server.service.vo.UserVo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -178,5 +181,18 @@ public class UserService {
         }
 
         return responseDto;
+    }
+
+    public List<BestMeetingTimeWithUsersVo> getBestMeetingInUsers(List<BestMeetingTimeVo> bestMeetingTimes) {
+        return bestMeetingTimes.stream()
+                .map(this::getBestMeetingTimeInUsers)
+                .collect(Collectors.toList());
+    }
+
+    private BestMeetingTimeWithUsersVo getBestMeetingTimeInUsers(final BestMeetingTimeVo bestMeetingTime) {
+        if (bestMeetingTime == null) return null;
+        List<TimeSlot> timeSlots = TimeSlot.getTimeSlots(bestMeetingTime.startTime().ordinal(), bestMeetingTime.endTime().ordinal());
+        List<UserVo> users = userRepository.findByAvailableDateAndTimeSlots(bestMeetingTime.availableDateId(), timeSlots);
+        return BestMeetingTimeWithUsersVo.of(bestMeetingTime, users);
     }
 }

--- a/src/main/java/com/asap/server/service/vo/BestMeetingTimeVo.java
+++ b/src/main/java/com/asap/server/service/vo/BestMeetingTimeVo.java
@@ -1,22 +1,8 @@
 package com.asap.server.service.vo;
 
 import com.asap.server.domain.enums.TimeSlot;
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.ToString;
 
 import java.time.LocalDate;
-import java.util.List;
 
-@Getter
-@ToString
-@AllArgsConstructor
-@EqualsAndHashCode
-public class BestMeetingTimeVo {
-    private LocalDate date;
-    private TimeSlot startTime;
-    private TimeSlot endTime;
-    private List<UserVo> users;
-    private int weight;
+public record BestMeetingTimeVo(LocalDate date, TimeSlot startTime, TimeSlot endTime, int weight) {
 }

--- a/src/main/java/com/asap/server/service/vo/BestMeetingTimeVo.java
+++ b/src/main/java/com/asap/server/service/vo/BestMeetingTimeVo.java
@@ -4,5 +4,5 @@ import com.asap.server.domain.enums.TimeSlot;
 
 import java.time.LocalDate;
 
-public record BestMeetingTimeVo(LocalDate date, TimeSlot startTime, TimeSlot endTime, int weight) {
+public record BestMeetingTimeVo(Long availableDateId, LocalDate date, TimeSlot startTime, TimeSlot endTime, int weight) {
 }

--- a/src/main/java/com/asap/server/service/vo/BestMeetingTimeWithUsersVo.java
+++ b/src/main/java/com/asap/server/service/vo/BestMeetingTimeWithUsersVo.java
@@ -1,0 +1,27 @@
+package com.asap.server.service.vo;
+
+import com.asap.server.domain.enums.TimeSlot;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record BestMeetingTimeWithUsersVo(
+        LocalDate date,
+        TimeSlot startTime,
+        TimeSlot endTime,
+        int weight,
+        List<UserVo> users
+) {
+    public static BestMeetingTimeWithUsersVo of(
+            final BestMeetingTimeVo bestMeetingTimeVo,
+            final List<UserVo> users
+    ) {
+        return new BestMeetingTimeWithUsersVo(
+                bestMeetingTimeVo.date(),
+                bestMeetingTimeVo.startTime(),
+                bestMeetingTimeVo.endTime(),
+                bestMeetingTimeVo.weight(),
+                users
+        );
+    }
+}

--- a/src/main/java/com/asap/server/service/vo/TimeBlockVo.java
+++ b/src/main/java/com/asap/server/service/vo/TimeBlockVo.java
@@ -15,14 +15,12 @@ import java.util.stream.Collectors;
 @AllArgsConstructor
 @ToString
 public class TimeBlockVo implements Comparable<TimeBlockVo> {
-    private Long id;
     private int weight;
     private TimeSlot timeSlot;
     private List<UserVo> users;
 
     public static TimeBlockVo of(TimeBlock timeBlock) {
         return new TimeBlockVo(
-                timeBlock.getId(),
                 timeBlock.getWeight(),
                 timeBlock.getTimeSlot(),
                 timeBlock.getTimeBlockUsers()

--- a/src/main/java/com/asap/server/service/vo/TimeBlockVo.java
+++ b/src/main/java/com/asap/server/service/vo/TimeBlockVo.java
@@ -4,7 +4,11 @@ import com.asap.server.domain.enums.TimeSlot;
 import com.querydsl.core.annotations.QueryProjection;
 import org.jetbrains.annotations.NotNull;
 
-public record TimeBlockVo(int weight, TimeSlot timeSlot, Long userCount) implements Comparable<TimeBlockVo> {
+public record TimeBlockVo(
+        int weight,
+        TimeSlot timeSlot,
+        Long userCount
+) implements Comparable<TimeBlockVo> {
     @QueryProjection
     public TimeBlockVo {
     }

--- a/src/main/java/com/asap/server/service/vo/TimeBlockVo.java
+++ b/src/main/java/com/asap/server/service/vo/TimeBlockVo.java
@@ -1,34 +1,12 @@
 package com.asap.server.service.vo;
 
-import com.asap.server.domain.TimeBlock;
-import com.asap.server.domain.TimeBlockUser;
 import com.asap.server.domain.enums.TimeSlot;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.ToString;
+import com.querydsl.core.annotations.QueryProjection;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
-@Getter
-@AllArgsConstructor
-@ToString
-public class TimeBlockVo implements Comparable<TimeBlockVo> {
-    private int weight;
-    private TimeSlot timeSlot;
-    private List<UserVo> users;
-
-    public static TimeBlockVo of(TimeBlock timeBlock) {
-        return new TimeBlockVo(
-                timeBlock.getWeight(),
-                timeBlock.getTimeSlot(),
-                timeBlock.getTimeBlockUsers()
-                        .stream()
-                        .map(TimeBlockUser::getUser)
-                        .map(UserVo::of)
-                        .collect(Collectors.toList())
-        );
+public record TimeBlockVo(int weight, TimeSlot timeSlot, Long userCount) implements Comparable<TimeBlockVo> {
+    @QueryProjection
+    public TimeBlockVo {
     }
 
     @Override

--- a/src/main/java/com/asap/server/service/vo/UserVo.java
+++ b/src/main/java/com/asap/server/service/vo/UserVo.java
@@ -1,18 +1,12 @@
 package com.asap.server.service.vo;
 
-import com.asap.server.domain.User;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.ToString;
+import com.querydsl.core.annotations.QueryProjection;
 
-@Getter
-@ToString
-@AllArgsConstructor
-public class UserVo {
-    private Long id;
-    private String name;
-
-    public static UserVo of(final User user) {
-        return new UserVo(user.getId(), user.getName());
+public record UserVo(
+        Long id,
+        String name
+) {
+    @QueryProjection
+    public UserVo {
     }
 }

--- a/src/test/java/com/asap/server/common/utils/GetBestMeetingTimeTest.java
+++ b/src/test/java/com/asap/server/common/utils/GetBestMeetingTimeTest.java
@@ -42,7 +42,7 @@ public class GetBestMeetingTimeTest {
         UserVo userVo = new UserVo(1L, "강원용");
         List<UserVo> users = List.of(userVo);
 
-        TimeBlockVo timeBlockByMeetingDate = new TimeBlockVo(1L, 0, SLOT_12_00, users);
+        TimeBlockVo timeBlockByMeetingDate = new TimeBlockVo(0, SLOT_12_00, users);
         List<TimeBlockVo> timeBlocks = new ArrayList<>(Arrays.asList(timeBlockByMeetingDate));
 
         LocalDate meetingDate = LocalDate.of(2023, 7, 10);
@@ -69,10 +69,10 @@ public class GetBestMeetingTimeTest {
         LocalDate meetingDate = LocalDate.of(2023, 7, 10);
         LocalDate meetingDate2 = LocalDate.of(2023, 7, 11);
 
-        TimeBlockVo timeBlockByMeetingDate = new TimeBlockVo(1L, 0, SLOT_12_00, users);
+        TimeBlockVo timeBlockByMeetingDate = new TimeBlockVo(0, SLOT_12_00, users);
         List<TimeBlockVo> timeBlocks = new ArrayList<>(Arrays.asList(timeBlockByMeetingDate));
 
-        TimeBlockVo timeBlockByMeetingDate2 = new TimeBlockVo(1L, 0, SLOT_12_30, users);
+        TimeBlockVo timeBlockByMeetingDate2 = new TimeBlockVo(0, SLOT_12_30, users);
         List<TimeBlockVo> timeBlocks2 = new ArrayList<>(Arrays.asList(timeBlockByMeetingDate2));
 
         TimeBlocksByDateVo timeBlocksByDate = new TimeBlocksByDateVo(1L, meetingDate, timeBlocks);
@@ -100,12 +100,12 @@ public class GetBestMeetingTimeTest {
         LocalDate meetingDate = LocalDate.of(2023, 7, 10);
         LocalDate meetingDate2 = LocalDate.of(2023, 7, 11);
 
-        TimeBlockVo timeBlockByMeetingDate = new TimeBlockVo(1L, 0, SLOT_12_00, users);
-        TimeBlockVo timeBlock2ByMeetingDate = new TimeBlockVo(1L, 0, SLOT_12_30, users);
+        TimeBlockVo timeBlockByMeetingDate = new TimeBlockVo(0, SLOT_12_00, users);
+        TimeBlockVo timeBlock2ByMeetingDate = new TimeBlockVo(0, SLOT_12_30, users);
         List<TimeBlockVo> timeBlocks = new ArrayList<>(Arrays.asList(timeBlockByMeetingDate, timeBlock2ByMeetingDate));
 
-        TimeBlockVo timeBlockByMeetingDate2 = new TimeBlockVo(1L, 0, SLOT_12_30, users);
-        TimeBlockVo timeBlock2ByMeetingDate2 = new TimeBlockVo(1L, 0, SLOT_13_00, users);
+        TimeBlockVo timeBlockByMeetingDate2 = new TimeBlockVo(0, SLOT_12_30, users);
+        TimeBlockVo timeBlock2ByMeetingDate2 = new TimeBlockVo(0, SLOT_13_00, users);
         List<TimeBlockVo> timeBlocks2 = new ArrayList<>(Arrays.asList(timeBlockByMeetingDate2, timeBlock2ByMeetingDate2));
 
         TimeBlocksByDateVo timeBlocksByDate = new TimeBlocksByDateVo(1L, meetingDate, timeBlocks);
@@ -134,12 +134,12 @@ public class GetBestMeetingTimeTest {
         LocalDate meetingDate = LocalDate.of(2023, 7, 10);
         LocalDate meetingDate2 = LocalDate.of(2023, 7, 11);
 
-        TimeBlockVo timeBlockByMeetingDate = new TimeBlockVo(1L, 0, SLOT_12_00, users);
-        TimeBlockVo timeBlock2ByMeetingDate = new TimeBlockVo(1L, 0, SLOT_12_30, users);
+        TimeBlockVo timeBlockByMeetingDate = new TimeBlockVo(0, SLOT_12_00, users);
+        TimeBlockVo timeBlock2ByMeetingDate = new TimeBlockVo(0, SLOT_12_30, users);
         List<TimeBlockVo> timeBlocks = new ArrayList<>(Arrays.asList(timeBlockByMeetingDate, timeBlock2ByMeetingDate));
 
-        TimeBlockVo timeBlockByMeetingDate2 = new TimeBlockVo(1L, 0, SLOT_12_30, users);
-        TimeBlockVo timeBlock2ByMeetingDate2 = new TimeBlockVo(1L, 0, SLOT_13_00, users);
+        TimeBlockVo timeBlockByMeetingDate2 = new TimeBlockVo(0, SLOT_12_30, users);
+        TimeBlockVo timeBlock2ByMeetingDate2 = new TimeBlockVo(0, SLOT_13_00, users);
         List<TimeBlockVo> timeBlocks2 = new ArrayList<>(Arrays.asList(timeBlockByMeetingDate2, timeBlock2ByMeetingDate2));
 
         TimeBlocksByDateVo timeBlocksByDate = new TimeBlocksByDateVo(1L, meetingDate, timeBlocks);
@@ -168,16 +168,16 @@ public class GetBestMeetingTimeTest {
         LocalDate meetingDate = LocalDate.of(2023, 7, 10);
         LocalDate meetingDate2 = LocalDate.of(2023, 7, 11);
 
-        TimeBlockVo timeBlockByMeetingDate = new TimeBlockVo(1L, 0, SLOT_12_00, users);
-        TimeBlockVo timeBlock2ByMeetingDate = new TimeBlockVo(1L, 0, SLOT_12_30, users);
-        TimeBlockVo timeBlock3ByMeetingDate = new TimeBlockVo(1L, 0, SLOT_13_00, users);
-        TimeBlockVo timeBlock4ByMeetingDate = new TimeBlockVo(1L, 0, SLOT_13_30, users);
+        TimeBlockVo timeBlockByMeetingDate = new TimeBlockVo(0, SLOT_12_00, users);
+        TimeBlockVo timeBlock2ByMeetingDate = new TimeBlockVo(0, SLOT_12_30, users);
+        TimeBlockVo timeBlock3ByMeetingDate = new TimeBlockVo(0, SLOT_13_00, users);
+        TimeBlockVo timeBlock4ByMeetingDate = new TimeBlockVo(0, SLOT_13_30, users);
         List<TimeBlockVo> timeBlocks = new ArrayList<>(Arrays.asList(timeBlockByMeetingDate, timeBlock2ByMeetingDate, timeBlock3ByMeetingDate, timeBlock4ByMeetingDate));
 
-        TimeBlockVo timeBlockByMeetingDate2 = new TimeBlockVo(1L, 0, SLOT_12_30, users);
-        TimeBlockVo timeBlock2ByMeetingDate2 = new TimeBlockVo(1L, 6, SLOT_13_00, users);
-        TimeBlockVo timeBlock3ByMeetingDate2 = new TimeBlockVo(1L, 6, SLOT_13_30, users);
-        TimeBlockVo timeBlock4ByMeetingDate2 = new TimeBlockVo(1L, 6, SLOT_14_00, users);
+        TimeBlockVo timeBlockByMeetingDate2 = new TimeBlockVo(0, SLOT_12_30, users);
+        TimeBlockVo timeBlock2ByMeetingDate2 = new TimeBlockVo(6, SLOT_13_00, users);
+        TimeBlockVo timeBlock3ByMeetingDate2 = new TimeBlockVo(6, SLOT_13_30, users);
+        TimeBlockVo timeBlock4ByMeetingDate2 = new TimeBlockVo(6, SLOT_14_00, users);
         List<TimeBlockVo> timeBlocks2 = new ArrayList<>(Arrays.asList(timeBlockByMeetingDate2, timeBlock2ByMeetingDate2, timeBlock3ByMeetingDate2, timeBlock4ByMeetingDate2));
 
         TimeBlocksByDateVo timeBlocksByDate = new TimeBlocksByDateVo(1L, meetingDate, timeBlocks);
@@ -204,7 +204,7 @@ public class GetBestMeetingTimeTest {
 
         LocalDate meetingDate = LocalDate.of(2023, 7, 10);
 
-        TimeBlockVo timeBlockByMeetingDate = new TimeBlockVo(1L, 0, SLOT_12_00, users);
+        TimeBlockVo timeBlockByMeetingDate = new TimeBlockVo(0, SLOT_12_00, users);
         List<TimeBlockVo> timeBlocks = new ArrayList<>(Arrays.asList(timeBlockByMeetingDate));
 
         TimeBlocksByDateVo timeBlocksByDate = new TimeBlocksByDateVo(1L, meetingDate, timeBlocks);

--- a/src/test/java/com/asap/server/common/utils/GetBestMeetingTimeTest.java
+++ b/src/test/java/com/asap/server/common/utils/GetBestMeetingTimeTest.java
@@ -42,7 +42,7 @@ public class GetBestMeetingTimeTest {
         UserVo userVo = new UserVo(1L, "강원용");
         List<UserVo> users = List.of(userVo);
 
-        TimeBlockVo timeBlockByMeetingDate = new TimeBlockVo(0, SLOT_12_00, users);
+        TimeBlockVo timeBlockByMeetingDate = new TimeBlockVo(0, SLOT_12_00, 1L);
         List<TimeBlockVo> timeBlocks = new ArrayList<>(Arrays.asList(timeBlockByMeetingDate));
 
         LocalDate meetingDate = LocalDate.of(2023, 7, 10);
@@ -50,7 +50,7 @@ public class GetBestMeetingTimeTest {
         TimeBlocksByDateVo timeBlocksByDate = new TimeBlocksByDateVo(1L, meetingDate, timeBlocks);
         List<TimeBlocksByDateVo> timeBlocksByDates = Arrays.asList(timeBlocksByDate);
 
-        BestMeetingTimeVo result = new BestMeetingTimeVo(meetingDate, SLOT_12_00, SLOT_12_30, users, 0);
+        BestMeetingTimeVo result = new BestMeetingTimeVo(meetingDate, SLOT_12_00, SLOT_12_30, 0);
 
         // when
         List<BestMeetingTimeVo> bestMeetingTimes = bestMeetingUtil.getBestMeetingTime(timeBlocksByDates, Duration.HALF, 1);
@@ -69,18 +69,18 @@ public class GetBestMeetingTimeTest {
         LocalDate meetingDate = LocalDate.of(2023, 7, 10);
         LocalDate meetingDate2 = LocalDate.of(2023, 7, 11);
 
-        TimeBlockVo timeBlockByMeetingDate = new TimeBlockVo(0, SLOT_12_00, users);
+        TimeBlockVo timeBlockByMeetingDate = new TimeBlockVo(0, SLOT_12_00, 1L);
         List<TimeBlockVo> timeBlocks = new ArrayList<>(Arrays.asList(timeBlockByMeetingDate));
 
-        TimeBlockVo timeBlockByMeetingDate2 = new TimeBlockVo(0, SLOT_12_30, users);
+        TimeBlockVo timeBlockByMeetingDate2 = new TimeBlockVo(0, SLOT_12_30, 1L);
         List<TimeBlockVo> timeBlocks2 = new ArrayList<>(Arrays.asList(timeBlockByMeetingDate2));
 
         TimeBlocksByDateVo timeBlocksByDate = new TimeBlocksByDateVo(1L, meetingDate, timeBlocks);
         TimeBlocksByDateVo timeBlocksByDate2 = new TimeBlocksByDateVo(2L, meetingDate2, timeBlocks2);
         List<TimeBlocksByDateVo> timeBlocksByDates = Arrays.asList(timeBlocksByDate, timeBlocksByDate2);
 
-        BestMeetingTimeVo result = new BestMeetingTimeVo(meetingDate, SLOT_12_00, SLOT_12_30, users, 0);
-        BestMeetingTimeVo result2 = new BestMeetingTimeVo(meetingDate2, SLOT_12_30, SLOT_13_00, users, 0);
+        BestMeetingTimeVo result = new BestMeetingTimeVo(meetingDate, SLOT_12_00, SLOT_12_30, 0);
+        BestMeetingTimeVo result2 = new BestMeetingTimeVo(meetingDate2, SLOT_12_30, SLOT_13_00, 0);
 
         // when
         List<BestMeetingTimeVo> bestMeetingTimes = bestMeetingUtil.getBestMeetingTime(timeBlocksByDates, Duration.HALF, 1);
@@ -100,21 +100,21 @@ public class GetBestMeetingTimeTest {
         LocalDate meetingDate = LocalDate.of(2023, 7, 10);
         LocalDate meetingDate2 = LocalDate.of(2023, 7, 11);
 
-        TimeBlockVo timeBlockByMeetingDate = new TimeBlockVo(0, SLOT_12_00, users);
-        TimeBlockVo timeBlock2ByMeetingDate = new TimeBlockVo(0, SLOT_12_30, users);
+        TimeBlockVo timeBlockByMeetingDate = new TimeBlockVo(0, SLOT_12_00, 2L);
+        TimeBlockVo timeBlock2ByMeetingDate = new TimeBlockVo(0, SLOT_12_30, 2L);
         List<TimeBlockVo> timeBlocks = new ArrayList<>(Arrays.asList(timeBlockByMeetingDate, timeBlock2ByMeetingDate));
 
-        TimeBlockVo timeBlockByMeetingDate2 = new TimeBlockVo(0, SLOT_12_30, users);
-        TimeBlockVo timeBlock2ByMeetingDate2 = new TimeBlockVo(0, SLOT_13_00, users);
+        TimeBlockVo timeBlockByMeetingDate2 = new TimeBlockVo(0, SLOT_12_30, 2L);
+        TimeBlockVo timeBlock2ByMeetingDate2 = new TimeBlockVo(0, SLOT_13_00, 2L);
         List<TimeBlockVo> timeBlocks2 = new ArrayList<>(Arrays.asList(timeBlockByMeetingDate2, timeBlock2ByMeetingDate2));
 
         TimeBlocksByDateVo timeBlocksByDate = new TimeBlocksByDateVo(1L, meetingDate, timeBlocks);
         TimeBlocksByDateVo timeBlocksByDate2 = new TimeBlocksByDateVo(2L, meetingDate2, timeBlocks2);
         List<TimeBlocksByDateVo> timeBlocksByDates = Arrays.asList(timeBlocksByDate, timeBlocksByDate2);
 
-        BestMeetingTimeVo result = new BestMeetingTimeVo(meetingDate, SLOT_12_00, SLOT_12_30, users, 0);
-        BestMeetingTimeVo result2 = new BestMeetingTimeVo(meetingDate, SLOT_12_30, SLOT_13_00, users, 0);
-        BestMeetingTimeVo result3 = new BestMeetingTimeVo(meetingDate2, SLOT_12_30, SLOT_13_00, users, 0);
+        BestMeetingTimeVo result = new BestMeetingTimeVo(meetingDate, SLOT_12_00, SLOT_12_30, 0);
+        BestMeetingTimeVo result2 = new BestMeetingTimeVo(meetingDate, SLOT_12_30, SLOT_13_00, 0);
+        BestMeetingTimeVo result3 = new BestMeetingTimeVo(meetingDate2, SLOT_12_30, SLOT_13_00, 0);
 
         // when
         List<BestMeetingTimeVo> bestMeetingTimes = bestMeetingUtil.getBestMeetingTime(timeBlocksByDates, Duration.HALF, 2);
@@ -134,21 +134,21 @@ public class GetBestMeetingTimeTest {
         LocalDate meetingDate = LocalDate.of(2023, 7, 10);
         LocalDate meetingDate2 = LocalDate.of(2023, 7, 11);
 
-        TimeBlockVo timeBlockByMeetingDate = new TimeBlockVo(0, SLOT_12_00, users);
-        TimeBlockVo timeBlock2ByMeetingDate = new TimeBlockVo(0, SLOT_12_30, users);
+        TimeBlockVo timeBlockByMeetingDate = new TimeBlockVo(0, SLOT_12_00, 2L);
+        TimeBlockVo timeBlock2ByMeetingDate = new TimeBlockVo(0, SLOT_12_30, 2L);
         List<TimeBlockVo> timeBlocks = new ArrayList<>(Arrays.asList(timeBlockByMeetingDate, timeBlock2ByMeetingDate));
 
-        TimeBlockVo timeBlockByMeetingDate2 = new TimeBlockVo(0, SLOT_12_30, users);
-        TimeBlockVo timeBlock2ByMeetingDate2 = new TimeBlockVo(0, SLOT_13_00, users);
+        TimeBlockVo timeBlockByMeetingDate2 = new TimeBlockVo(0, SLOT_12_30, 2L);
+        TimeBlockVo timeBlock2ByMeetingDate2 = new TimeBlockVo(0, SLOT_13_00, 2L);
         List<TimeBlockVo> timeBlocks2 = new ArrayList<>(Arrays.asList(timeBlockByMeetingDate2, timeBlock2ByMeetingDate2));
 
         TimeBlocksByDateVo timeBlocksByDate = new TimeBlocksByDateVo(1L, meetingDate, timeBlocks);
         TimeBlocksByDateVo timeBlocksByDate2 = new TimeBlocksByDateVo(2L, meetingDate2, timeBlocks2);
         List<TimeBlocksByDateVo> timeBlocksByDates = Arrays.asList(timeBlocksByDate, timeBlocksByDate2);
 
-        BestMeetingTimeVo result = new BestMeetingTimeVo(meetingDate, SLOT_12_00, SLOT_13_00, users, 0);
-        BestMeetingTimeVo result2 = new BestMeetingTimeVo(meetingDate2, SLOT_12_30, SLOT_13_30, users, 0);
-        BestMeetingTimeVo result3 = new BestMeetingTimeVo(meetingDate, SLOT_12_00, SLOT_12_30, users, 0);
+        BestMeetingTimeVo result = new BestMeetingTimeVo(meetingDate, SLOT_12_00, SLOT_13_00, 0);
+        BestMeetingTimeVo result2 = new BestMeetingTimeVo(meetingDate2, SLOT_12_30, SLOT_13_30, 0);
+        BestMeetingTimeVo result3 = new BestMeetingTimeVo(meetingDate, SLOT_12_00, SLOT_12_30, 0);
 
         // when
         List<BestMeetingTimeVo> bestMeetingTimes = bestMeetingUtil.getBestMeetingTime(timeBlocksByDates, Duration.HOUR, 2);
@@ -168,25 +168,25 @@ public class GetBestMeetingTimeTest {
         LocalDate meetingDate = LocalDate.of(2023, 7, 10);
         LocalDate meetingDate2 = LocalDate.of(2023, 7, 11);
 
-        TimeBlockVo timeBlockByMeetingDate = new TimeBlockVo(0, SLOT_12_00, users);
-        TimeBlockVo timeBlock2ByMeetingDate = new TimeBlockVo(0, SLOT_12_30, users);
-        TimeBlockVo timeBlock3ByMeetingDate = new TimeBlockVo(0, SLOT_13_00, users);
-        TimeBlockVo timeBlock4ByMeetingDate = new TimeBlockVo(0, SLOT_13_30, users);
+        TimeBlockVo timeBlockByMeetingDate = new TimeBlockVo(0, SLOT_12_00, 2L);
+        TimeBlockVo timeBlock2ByMeetingDate = new TimeBlockVo(0, SLOT_12_30, 2L);
+        TimeBlockVo timeBlock3ByMeetingDate = new TimeBlockVo(0, SLOT_13_00, 2L);
+        TimeBlockVo timeBlock4ByMeetingDate = new TimeBlockVo(0, SLOT_13_30, 2L);
         List<TimeBlockVo> timeBlocks = new ArrayList<>(Arrays.asList(timeBlockByMeetingDate, timeBlock2ByMeetingDate, timeBlock3ByMeetingDate, timeBlock4ByMeetingDate));
 
-        TimeBlockVo timeBlockByMeetingDate2 = new TimeBlockVo(0, SLOT_12_30, users);
-        TimeBlockVo timeBlock2ByMeetingDate2 = new TimeBlockVo(6, SLOT_13_00, users);
-        TimeBlockVo timeBlock3ByMeetingDate2 = new TimeBlockVo(6, SLOT_13_30, users);
-        TimeBlockVo timeBlock4ByMeetingDate2 = new TimeBlockVo(6, SLOT_14_00, users);
+        TimeBlockVo timeBlockByMeetingDate2 = new TimeBlockVo(0, SLOT_12_30, 2L);
+        TimeBlockVo timeBlock2ByMeetingDate2 = new TimeBlockVo(6, SLOT_13_00, 2L);
+        TimeBlockVo timeBlock3ByMeetingDate2 = new TimeBlockVo(6, SLOT_13_30, 2L);
+        TimeBlockVo timeBlock4ByMeetingDate2 = new TimeBlockVo(6, SLOT_14_00, 2L);
         List<TimeBlockVo> timeBlocks2 = new ArrayList<>(Arrays.asList(timeBlockByMeetingDate2, timeBlock2ByMeetingDate2, timeBlock3ByMeetingDate2, timeBlock4ByMeetingDate2));
 
         TimeBlocksByDateVo timeBlocksByDate = new TimeBlocksByDateVo(1L, meetingDate, timeBlocks);
         TimeBlocksByDateVo timeBlocksByDate2 = new TimeBlocksByDateVo(2L, meetingDate2, timeBlocks2);
         List<TimeBlocksByDateVo> timeBlocksByDates = Arrays.asList(timeBlocksByDate, timeBlocksByDate2);
 
-        BestMeetingTimeVo result = new BestMeetingTimeVo(meetingDate2, SLOT_13_00, SLOT_14_30, users, 18);
-        BestMeetingTimeVo result2 = new BestMeetingTimeVo(meetingDate2, SLOT_12_30, SLOT_14_00, users, 12);
-        BestMeetingTimeVo result3 = new BestMeetingTimeVo(meetingDate, SLOT_12_00, SLOT_13_30, users, 0);
+        BestMeetingTimeVo result = new BestMeetingTimeVo(meetingDate2, SLOT_13_00, SLOT_14_30, 18);
+        BestMeetingTimeVo result2 = new BestMeetingTimeVo(meetingDate2, SLOT_12_30, SLOT_14_00, 12);
+        BestMeetingTimeVo result3 = new BestMeetingTimeVo(meetingDate, SLOT_12_00, SLOT_13_30, 0);
 
         // when
         List<BestMeetingTimeVo> bestMeetingTimes = bestMeetingUtil.getBestMeetingTime(timeBlocksByDates, Duration.HOUR_HALF, 2);
@@ -204,13 +204,13 @@ public class GetBestMeetingTimeTest {
 
         LocalDate meetingDate = LocalDate.of(2023, 7, 10);
 
-        TimeBlockVo timeBlockByMeetingDate = new TimeBlockVo(0, SLOT_12_00, users);
+        TimeBlockVo timeBlockByMeetingDate = new TimeBlockVo(0, SLOT_12_00, 1L);
         List<TimeBlockVo> timeBlocks = new ArrayList<>(Arrays.asList(timeBlockByMeetingDate));
 
         TimeBlocksByDateVo timeBlocksByDate = new TimeBlocksByDateVo(1L, meetingDate, timeBlocks);
         List<TimeBlocksByDateVo> timeBlocksByDates = Arrays.asList(timeBlocksByDate);
 
-        BestMeetingTimeVo result = new BestMeetingTimeVo(meetingDate, SLOT_12_00, SLOT_12_30, users, 0);
+        BestMeetingTimeVo result = new BestMeetingTimeVo(meetingDate, SLOT_12_00, SLOT_12_30, 0);
 
         // when
         List<BestMeetingTimeVo> bestMeetingTimes = bestMeetingUtil.getBestMeetingTime(timeBlocksByDates, Duration.HALF, 2);

--- a/src/test/java/com/asap/server/common/utils/GetBestMeetingTimeTest.java
+++ b/src/test/java/com/asap/server/common/utils/GetBestMeetingTimeTest.java
@@ -50,7 +50,7 @@ public class GetBestMeetingTimeTest {
         TimeBlocksByDateVo timeBlocksByDate = new TimeBlocksByDateVo(1L, meetingDate, timeBlocks);
         List<TimeBlocksByDateVo> timeBlocksByDates = Arrays.asList(timeBlocksByDate);
 
-        BestMeetingTimeVo result = new BestMeetingTimeVo(meetingDate, SLOT_12_00, SLOT_12_30, 0);
+        BestMeetingTimeVo result = new BestMeetingTimeVo(1L, meetingDate, SLOT_12_00, SLOT_12_30, 0);
 
         // when
         List<BestMeetingTimeVo> bestMeetingTimes = bestMeetingUtil.getBestMeetingTime(timeBlocksByDates, Duration.HALF, 1);
@@ -79,8 +79,8 @@ public class GetBestMeetingTimeTest {
         TimeBlocksByDateVo timeBlocksByDate2 = new TimeBlocksByDateVo(2L, meetingDate2, timeBlocks2);
         List<TimeBlocksByDateVo> timeBlocksByDates = Arrays.asList(timeBlocksByDate, timeBlocksByDate2);
 
-        BestMeetingTimeVo result = new BestMeetingTimeVo(meetingDate, SLOT_12_00, SLOT_12_30, 0);
-        BestMeetingTimeVo result2 = new BestMeetingTimeVo(meetingDate2, SLOT_12_30, SLOT_13_00, 0);
+        BestMeetingTimeVo result = new BestMeetingTimeVo(1L, meetingDate, SLOT_12_00, SLOT_12_30, 0);
+        BestMeetingTimeVo result2 = new BestMeetingTimeVo(2L, meetingDate2, SLOT_12_30, SLOT_13_00, 0);
 
         // when
         List<BestMeetingTimeVo> bestMeetingTimes = bestMeetingUtil.getBestMeetingTime(timeBlocksByDates, Duration.HALF, 1);
@@ -112,9 +112,9 @@ public class GetBestMeetingTimeTest {
         TimeBlocksByDateVo timeBlocksByDate2 = new TimeBlocksByDateVo(2L, meetingDate2, timeBlocks2);
         List<TimeBlocksByDateVo> timeBlocksByDates = Arrays.asList(timeBlocksByDate, timeBlocksByDate2);
 
-        BestMeetingTimeVo result = new BestMeetingTimeVo(meetingDate, SLOT_12_00, SLOT_12_30, 0);
-        BestMeetingTimeVo result2 = new BestMeetingTimeVo(meetingDate, SLOT_12_30, SLOT_13_00, 0);
-        BestMeetingTimeVo result3 = new BestMeetingTimeVo(meetingDate2, SLOT_12_30, SLOT_13_00, 0);
+        BestMeetingTimeVo result = new BestMeetingTimeVo(1L, meetingDate, SLOT_12_00, SLOT_12_30, 0);
+        BestMeetingTimeVo result2 = new BestMeetingTimeVo(1L, meetingDate, SLOT_12_30, SLOT_13_00, 0);
+        BestMeetingTimeVo result3 = new BestMeetingTimeVo(2L, meetingDate2, SLOT_12_30, SLOT_13_00, 0);
 
         // when
         List<BestMeetingTimeVo> bestMeetingTimes = bestMeetingUtil.getBestMeetingTime(timeBlocksByDates, Duration.HALF, 2);
@@ -146,9 +146,9 @@ public class GetBestMeetingTimeTest {
         TimeBlocksByDateVo timeBlocksByDate2 = new TimeBlocksByDateVo(2L, meetingDate2, timeBlocks2);
         List<TimeBlocksByDateVo> timeBlocksByDates = Arrays.asList(timeBlocksByDate, timeBlocksByDate2);
 
-        BestMeetingTimeVo result = new BestMeetingTimeVo(meetingDate, SLOT_12_00, SLOT_13_00, 0);
-        BestMeetingTimeVo result2 = new BestMeetingTimeVo(meetingDate2, SLOT_12_30, SLOT_13_30, 0);
-        BestMeetingTimeVo result3 = new BestMeetingTimeVo(meetingDate, SLOT_12_00, SLOT_12_30, 0);
+        BestMeetingTimeVo result = new BestMeetingTimeVo(1L, meetingDate, SLOT_12_00, SLOT_13_00, 0);
+        BestMeetingTimeVo result2 = new BestMeetingTimeVo(2L, meetingDate2, SLOT_12_30, SLOT_13_30, 0);
+        BestMeetingTimeVo result3 = new BestMeetingTimeVo(1L, meetingDate, SLOT_12_00, SLOT_12_30, 0);
 
         // when
         List<BestMeetingTimeVo> bestMeetingTimes = bestMeetingUtil.getBestMeetingTime(timeBlocksByDates, Duration.HOUR, 2);
@@ -184,9 +184,9 @@ public class GetBestMeetingTimeTest {
         TimeBlocksByDateVo timeBlocksByDate2 = new TimeBlocksByDateVo(2L, meetingDate2, timeBlocks2);
         List<TimeBlocksByDateVo> timeBlocksByDates = Arrays.asList(timeBlocksByDate, timeBlocksByDate2);
 
-        BestMeetingTimeVo result = new BestMeetingTimeVo(meetingDate2, SLOT_13_00, SLOT_14_30, 18);
-        BestMeetingTimeVo result2 = new BestMeetingTimeVo(meetingDate2, SLOT_12_30, SLOT_14_00, 12);
-        BestMeetingTimeVo result3 = new BestMeetingTimeVo(meetingDate, SLOT_12_00, SLOT_13_30, 0);
+        BestMeetingTimeVo result = new BestMeetingTimeVo(2L, meetingDate2, SLOT_13_00, SLOT_14_30, 18);
+        BestMeetingTimeVo result2 = new BestMeetingTimeVo(2L, meetingDate2, SLOT_12_30, SLOT_14_00, 12);
+        BestMeetingTimeVo result3 = new BestMeetingTimeVo(1L, meetingDate, SLOT_12_00, SLOT_13_30, 0);
 
         // when
         List<BestMeetingTimeVo> bestMeetingTimes = bestMeetingUtil.getBestMeetingTime(timeBlocksByDates, Duration.HOUR_HALF, 2);
@@ -210,7 +210,7 @@ public class GetBestMeetingTimeTest {
         TimeBlocksByDateVo timeBlocksByDate = new TimeBlocksByDateVo(1L, meetingDate, timeBlocks);
         List<TimeBlocksByDateVo> timeBlocksByDates = Arrays.asList(timeBlocksByDate);
 
-        BestMeetingTimeVo result = new BestMeetingTimeVo(meetingDate, SLOT_12_00, SLOT_12_30, 0);
+        BestMeetingTimeVo result = new BestMeetingTimeVo(1L, meetingDate, SLOT_12_00, SLOT_12_30, 0);
 
         // when
         List<BestMeetingTimeVo> bestMeetingTimes = bestMeetingUtil.getBestMeetingTime(timeBlocksByDates, Duration.HALF, 2);

--- a/src/test/java/com/asap/server/common/utils/strategy/FindBestMeetingTimeStrategyTest.java
+++ b/src/test/java/com/asap/server/common/utils/strategy/FindBestMeetingTimeStrategyTest.java
@@ -45,22 +45,22 @@ class FindBestMeetingTimeStrategyTest {
         UserVo dsy = new UserVo(1L, "DSY");
         List<UserVo> users = List.of(kwy, dsy);
 
-        TimeBlockVo timeBlock = new TimeBlockVo(0, SLOT_11_00, users);
-        TimeBlockVo timeBlock2 = new TimeBlockVo(0, SLOT_11_30, users);
-        TimeBlockVo timeBlock3 = new TimeBlockVo(0, SLOT_12_00, users);
-        TimeBlockVo timeBlock4 = new TimeBlockVo(0, SLOT_12_30, users);
-        TimeBlockVo timeBlock5 = new TimeBlockVo(0, SLOT_13_00, users);
-        TimeBlockVo timeBlock6 = new TimeBlockVo(0, SLOT_13_30, users);
-        TimeBlockVo timeBlock7 = new TimeBlockVo(0, SLOT_14_00, users);
+        TimeBlockVo timeBlock = new TimeBlockVo(0, SLOT_11_00, 2L);
+        TimeBlockVo timeBlock2 = new TimeBlockVo(0, SLOT_11_30, 2L);
+        TimeBlockVo timeBlock3 = new TimeBlockVo(0, SLOT_12_00, 2L);
+        TimeBlockVo timeBlock4 = new TimeBlockVo(0, SLOT_12_30, 2L);
+        TimeBlockVo timeBlock5 = new TimeBlockVo(0, SLOT_13_00, 2L);
+        TimeBlockVo timeBlock6 = new TimeBlockVo(0, SLOT_13_30, 2L);
+        TimeBlockVo timeBlock7 = new TimeBlockVo(0, SLOT_14_00, 2L);
         List<TimeBlockVo> timeBlocks = new ArrayList<>(Arrays.asList(timeBlock, timeBlock2, timeBlock3, timeBlock4, timeBlock5, timeBlock6, timeBlock7));
 
         LocalDate meetingDate = LocalDate.of(2023, 9, 8);
         TimeBlocksByDateVo availableDate = new TimeBlocksByDateVo(1L, meetingDate, timeBlocks);
 
-        BestMeetingTimeVo bestMeetingTime = new BestMeetingTimeVo(meetingDate, SLOT_11_00, SLOT_13_00, users, 0);
-        BestMeetingTimeVo bestMeetingTime2 = new BestMeetingTimeVo(meetingDate, SLOT_11_30, SLOT_13_30, users, 0);
-        BestMeetingTimeVo bestMeetingTime3 = new BestMeetingTimeVo(meetingDate, SLOT_12_00, SLOT_14_00, users, 0);
-        BestMeetingTimeVo bestMeetingTime4 = new BestMeetingTimeVo(meetingDate, SLOT_12_30, SLOT_14_30, users, 0);
+        BestMeetingTimeVo bestMeetingTime = new BestMeetingTimeVo(meetingDate, SLOT_11_00, SLOT_13_00, 0);
+        BestMeetingTimeVo bestMeetingTime2 = new BestMeetingTimeVo(meetingDate, SLOT_11_30, SLOT_13_30, 0);
+        BestMeetingTimeVo bestMeetingTime3 = new BestMeetingTimeVo(meetingDate, SLOT_12_00, SLOT_14_00, 0);
+        BestMeetingTimeVo bestMeetingTime4 = new BestMeetingTimeVo(meetingDate, SLOT_12_30, SLOT_14_30, 0);
         List<BestMeetingTimeVo> bestMeetingTimes = new ArrayList<>(List.of(bestMeetingTime, bestMeetingTime2, bestMeetingTime3, bestMeetingTime4));
 
         // when
@@ -78,26 +78,26 @@ class FindBestMeetingTimeStrategyTest {
         UserVo dsy = new UserVo(1L, "DSY");
         List<UserVo> users = List.of(kwy, dsy);
 
-        TimeBlockVo timeBlock = new TimeBlockVo(0, SLOT_11_00, users);
-        TimeBlockVo timeBlock2 = new TimeBlockVo(0, SLOT_11_30, users);
-        TimeBlockVo timeBlock3 = new TimeBlockVo(0, SLOT_12_00, users);
+        TimeBlockVo timeBlock = new TimeBlockVo(0, SLOT_11_00, 2L);
+        TimeBlockVo timeBlock2 = new TimeBlockVo(0, SLOT_11_30, 2L);
+        TimeBlockVo timeBlock3 = new TimeBlockVo(0, SLOT_12_00, 2L);
 
-        TimeBlockVo timeBlock4 = new TimeBlockVo(0, SLOT_12_30, List.of(kwy));
-        TimeBlockVo timeBlock5 = new TimeBlockVo(0, SLOT_13_00, List.of(kwy));
-        TimeBlockVo timeBlock6 = new TimeBlockVo(0, SLOT_13_30, List.of(kwy));
+        TimeBlockVo timeBlock4 = new TimeBlockVo(0, SLOT_12_30, 1L);
+        TimeBlockVo timeBlock5 = new TimeBlockVo(0, SLOT_13_00, 1L);
+        TimeBlockVo timeBlock6 = new TimeBlockVo(0, SLOT_13_30, 1L);
 
-        TimeBlockVo timeBlock7 = new TimeBlockVo(0, SLOT_20_00, users);
-        TimeBlockVo timeBlock8 = new TimeBlockVo(0, SLOT_20_30, users);
-        TimeBlockVo timeBlock9 = new TimeBlockVo(0, SLOT_21_00, users);
+        TimeBlockVo timeBlock7 = new TimeBlockVo(0, SLOT_20_00, 2L);
+        TimeBlockVo timeBlock8 = new TimeBlockVo(0, SLOT_20_30, 2L);
+        TimeBlockVo timeBlock9 = new TimeBlockVo(0, SLOT_21_00, 2L);
         List<TimeBlockVo> timeBlocks = new ArrayList<>(Arrays.asList(timeBlock, timeBlock2, timeBlock3, timeBlock4, timeBlock5, timeBlock6, timeBlock7, timeBlock8, timeBlock9));
 
         LocalDate meetingDate = LocalDate.of(2023, 9, 8);
         TimeBlocksByDateVo availableDate = new TimeBlocksByDateVo(1L, meetingDate, timeBlocks);
 
-        BestMeetingTimeVo bestMeetingTime = new BestMeetingTimeVo(meetingDate, SLOT_11_00, SLOT_12_00, users, 0);
-        BestMeetingTimeVo bestMeetingTime2 = new BestMeetingTimeVo(meetingDate, SLOT_11_30, SLOT_12_30, users, 0);
-        BestMeetingTimeVo bestMeetingTime3 = new BestMeetingTimeVo(meetingDate, SLOT_20_00, SLOT_21_00, users, 0);
-        BestMeetingTimeVo bestMeetingTime4 = new BestMeetingTimeVo(meetingDate, SLOT_20_30, SLOT_21_30, users, 0);
+        BestMeetingTimeVo bestMeetingTime = new BestMeetingTimeVo(meetingDate, SLOT_11_00, SLOT_12_00, 0);
+        BestMeetingTimeVo bestMeetingTime2 = new BestMeetingTimeVo(meetingDate, SLOT_11_30, SLOT_12_30, 0);
+        BestMeetingTimeVo bestMeetingTime3 = new BestMeetingTimeVo(meetingDate, SLOT_20_00, SLOT_21_00, 0);
+        BestMeetingTimeVo bestMeetingTime4 = new BestMeetingTimeVo(meetingDate, SLOT_20_30, SLOT_21_30, 0);
         List<BestMeetingTimeVo> bestMeetingTimes = new ArrayList<>(List.of(bestMeetingTime, bestMeetingTime2, bestMeetingTime3, bestMeetingTime4));
 
         // when

--- a/src/test/java/com/asap/server/common/utils/strategy/FindBestMeetingTimeStrategyTest.java
+++ b/src/test/java/com/asap/server/common/utils/strategy/FindBestMeetingTimeStrategyTest.java
@@ -45,13 +45,13 @@ class FindBestMeetingTimeStrategyTest {
         UserVo dsy = new UserVo(1L, "DSY");
         List<UserVo> users = List.of(kwy, dsy);
 
-        TimeBlockVo timeBlock = new TimeBlockVo(1L, 0, SLOT_11_00, users);
-        TimeBlockVo timeBlock2 = new TimeBlockVo(1L, 0, SLOT_11_30, users);
-        TimeBlockVo timeBlock3 = new TimeBlockVo(1L, 0, SLOT_12_00, users);
-        TimeBlockVo timeBlock4 = new TimeBlockVo(1L, 0, SLOT_12_30, users);
-        TimeBlockVo timeBlock5 = new TimeBlockVo(1L, 0, SLOT_13_00, users);
-        TimeBlockVo timeBlock6 = new TimeBlockVo(1L, 0, SLOT_13_30, users);
-        TimeBlockVo timeBlock7 = new TimeBlockVo(1L, 0, SLOT_14_00, users);
+        TimeBlockVo timeBlock = new TimeBlockVo(0, SLOT_11_00, users);
+        TimeBlockVo timeBlock2 = new TimeBlockVo(0, SLOT_11_30, users);
+        TimeBlockVo timeBlock3 = new TimeBlockVo(0, SLOT_12_00, users);
+        TimeBlockVo timeBlock4 = new TimeBlockVo(0, SLOT_12_30, users);
+        TimeBlockVo timeBlock5 = new TimeBlockVo(0, SLOT_13_00, users);
+        TimeBlockVo timeBlock6 = new TimeBlockVo(0, SLOT_13_30, users);
+        TimeBlockVo timeBlock7 = new TimeBlockVo(0, SLOT_14_00, users);
         List<TimeBlockVo> timeBlocks = new ArrayList<>(Arrays.asList(timeBlock, timeBlock2, timeBlock3, timeBlock4, timeBlock5, timeBlock6, timeBlock7));
 
         LocalDate meetingDate = LocalDate.of(2023, 9, 8);
@@ -78,17 +78,17 @@ class FindBestMeetingTimeStrategyTest {
         UserVo dsy = new UserVo(1L, "DSY");
         List<UserVo> users = List.of(kwy, dsy);
 
-        TimeBlockVo timeBlock = new TimeBlockVo(1L, 0, SLOT_11_00, users);
-        TimeBlockVo timeBlock2 = new TimeBlockVo(1L, 0, SLOT_11_30, users);
-        TimeBlockVo timeBlock3 = new TimeBlockVo(1L, 0, SLOT_12_00, users);
+        TimeBlockVo timeBlock = new TimeBlockVo(0, SLOT_11_00, users);
+        TimeBlockVo timeBlock2 = new TimeBlockVo(0, SLOT_11_30, users);
+        TimeBlockVo timeBlock3 = new TimeBlockVo(0, SLOT_12_00, users);
 
-        TimeBlockVo timeBlock4 = new TimeBlockVo(1L, 0, SLOT_12_30, List.of(kwy));
-        TimeBlockVo timeBlock5 = new TimeBlockVo(1L, 0, SLOT_13_00, List.of(kwy));
-        TimeBlockVo timeBlock6 = new TimeBlockVo(1L, 0, SLOT_13_30, List.of(kwy));
+        TimeBlockVo timeBlock4 = new TimeBlockVo(0, SLOT_12_30, List.of(kwy));
+        TimeBlockVo timeBlock5 = new TimeBlockVo(0, SLOT_13_00, List.of(kwy));
+        TimeBlockVo timeBlock6 = new TimeBlockVo(0, SLOT_13_30, List.of(kwy));
 
-        TimeBlockVo timeBlock7 = new TimeBlockVo(1L, 0, SLOT_20_00, users);
-        TimeBlockVo timeBlock8 = new TimeBlockVo(1L, 0, SLOT_20_30, users);
-        TimeBlockVo timeBlock9 = new TimeBlockVo(1L, 0, SLOT_21_00, users);
+        TimeBlockVo timeBlock7 = new TimeBlockVo(0, SLOT_20_00, users);
+        TimeBlockVo timeBlock8 = new TimeBlockVo(0, SLOT_20_30, users);
+        TimeBlockVo timeBlock9 = new TimeBlockVo(0, SLOT_21_00, users);
         List<TimeBlockVo> timeBlocks = new ArrayList<>(Arrays.asList(timeBlock, timeBlock2, timeBlock3, timeBlock4, timeBlock5, timeBlock6, timeBlock7, timeBlock8, timeBlock9));
 
         LocalDate meetingDate = LocalDate.of(2023, 9, 8);

--- a/src/test/java/com/asap/server/common/utils/strategy/FindBestMeetingTimeStrategyTest.java
+++ b/src/test/java/com/asap/server/common/utils/strategy/FindBestMeetingTimeStrategyTest.java
@@ -57,10 +57,10 @@ class FindBestMeetingTimeStrategyTest {
         LocalDate meetingDate = LocalDate.of(2023, 9, 8);
         TimeBlocksByDateVo availableDate = new TimeBlocksByDateVo(1L, meetingDate, timeBlocks);
 
-        BestMeetingTimeVo bestMeetingTime = new BestMeetingTimeVo(meetingDate, SLOT_11_00, SLOT_13_00, 0);
-        BestMeetingTimeVo bestMeetingTime2 = new BestMeetingTimeVo(meetingDate, SLOT_11_30, SLOT_13_30, 0);
-        BestMeetingTimeVo bestMeetingTime3 = new BestMeetingTimeVo(meetingDate, SLOT_12_00, SLOT_14_00, 0);
-        BestMeetingTimeVo bestMeetingTime4 = new BestMeetingTimeVo(meetingDate, SLOT_12_30, SLOT_14_30, 0);
+        BestMeetingTimeVo bestMeetingTime = new BestMeetingTimeVo(1L,meetingDate, SLOT_11_00, SLOT_13_00, 0);
+        BestMeetingTimeVo bestMeetingTime2 = new BestMeetingTimeVo(1L,meetingDate, SLOT_11_30, SLOT_13_30, 0);
+        BestMeetingTimeVo bestMeetingTime3 = new BestMeetingTimeVo(1L,meetingDate, SLOT_12_00, SLOT_14_00, 0);
+        BestMeetingTimeVo bestMeetingTime4 = new BestMeetingTimeVo(1L,meetingDate, SLOT_12_30, SLOT_14_30, 0);
         List<BestMeetingTimeVo> bestMeetingTimes = new ArrayList<>(List.of(bestMeetingTime, bestMeetingTime2, bestMeetingTime3, bestMeetingTime4));
 
         // when
@@ -94,10 +94,10 @@ class FindBestMeetingTimeStrategyTest {
         LocalDate meetingDate = LocalDate.of(2023, 9, 8);
         TimeBlocksByDateVo availableDate = new TimeBlocksByDateVo(1L, meetingDate, timeBlocks);
 
-        BestMeetingTimeVo bestMeetingTime = new BestMeetingTimeVo(meetingDate, SLOT_11_00, SLOT_12_00, 0);
-        BestMeetingTimeVo bestMeetingTime2 = new BestMeetingTimeVo(meetingDate, SLOT_11_30, SLOT_12_30, 0);
-        BestMeetingTimeVo bestMeetingTime3 = new BestMeetingTimeVo(meetingDate, SLOT_20_00, SLOT_21_00, 0);
-        BestMeetingTimeVo bestMeetingTime4 = new BestMeetingTimeVo(meetingDate, SLOT_20_30, SLOT_21_30, 0);
+        BestMeetingTimeVo bestMeetingTime = new BestMeetingTimeVo(1L,meetingDate, SLOT_11_00, SLOT_12_00, 0);
+        BestMeetingTimeVo bestMeetingTime2 = new BestMeetingTimeVo(1L,meetingDate, SLOT_11_30, SLOT_12_30, 0);
+        BestMeetingTimeVo bestMeetingTime3 = new BestMeetingTimeVo(1L,meetingDate, SLOT_20_00, SLOT_21_00, 0);
+        BestMeetingTimeVo bestMeetingTime4 = new BestMeetingTimeVo(1L,meetingDate, SLOT_20_30, SLOT_21_30, 0);
         List<BestMeetingTimeVo> bestMeetingTimes = new ArrayList<>(List.of(bestMeetingTime, bestMeetingTime2, bestMeetingTime3, bestMeetingTime4));
 
         // when


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #245 

## Key Changes 🔑
1. 내용
   - QueryDsl을 활용하여 최적의 회의 시간 알고리즘 수정

## To Reviewers 📢
이전 알고리즘 방식에서는 쿼리가 아래와 같이 실행되었습니다.

- 회의 정보를 불러오는 SELECT 쿼리 1 번 실행
- 회의에 참여한 총 인원을 불러오는 SELECT 쿼리 1번 실행
- 총 AvailableDate 데이터를 불러오는 SELECT 쿼리 1번 실행
- 유저 N 명당 select 쿼리 N번 실행 (N ≥ 1)
- AvailableDate 데이터 M개 당 총 TimeBlock 데이터를 불러오는 SELECT 쿼리 M번 실행 (1≤ M ≤ 7)
- TimeBlock 데이터 K개 당 SELECT 쿼리 K번 실행 (1≤ K ≤ 259)
    
    AvailableDate 당 37개의 TimeBlock이 생성될 수 있으므로 최악의 경우 37 * 7 = 259 개의 데이터가 생긴다.
    

그래서 최악의 경우 1 + 1 + 1 + N + 7 + 259 , 즉 N + 266 개의 쿼리가 실행됩니다.

---

쿼리 수를 줄이기 위해서 알고리즘 일부를 수정했습니다. 

- 알고리즘 내부에서 TimeBlock users를 사용하지 않고 users의 size만 필요하기 때문에 users를 구하기 위해 K번의 쿼리를 실행하지 않는 대신에 groupBy를 통해서 users의 size 값을 구한다.
- 최적, 차선의 회의 시간대를 3개 구한 후, 3개의 회의 시간대에 참여할 수 있는 users를 따로 구한다.

이러한 알고리즘 방식을 통해서 쿼리가 아래와 같이 개선되었습니다.

- 회의 정보를 불러오는 SELECT 쿼리 1 번 실행
- 회의에 참여한 총 인원을 불러오는 SELECT 쿼리 1번 실행
- 총 AvailableDate 데이터를 불러오는 SELECT 쿼리 1번 실행
- AvailableDate 데이터 M개 당 총 TimeBlock을 불러오는 SELECT 쿼리 M번 실행 (1≤ M ≤ 7)
- 최적, 차선의 회의 시간에 참여하는 User를 불러오는 SELECT 쿼리 3번 실행

그래서 최악의 경우 1 + 1 + 1  + 7 + 3 , 즉 13 개의 쿼리가 실행되며, 최소 7개의 쿼리가 실행됩니다.
