### PR TITLE
#250 [fix] 최적의 회의 시간대의 가중치가 차선의 회의 시간대의 가중치 보다 낮을 때 발생하는 오류 해결

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -20,6 +20,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Setup MySQL
+      uses: samin/mysql-action@v1
+      with:
+        character set server: 'utf8'
+        mysql database: 'asap_dev'
+        mysql user: 'asap_dev_admin'
+        mysql password: ${{ secrets.DatabasePassword }}
+        
     - uses: actions/checkout@v3
     - name: Set up JDK 17
       uses: actions/setup-java@v3

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Set up JDK 11
       uses: actions/setup-java@v3
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'temurin'
     
     # 3) 환경변수 파일 생성

--- a/.github/workflows/prod-ci.yml
+++ b/.github/workflows/prod-ci.yml
@@ -13,6 +13,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: mirromutth/mysql-action@v1.1
+        with:
+          host port: 3306
+          container port: 3306
+          mysql database: 'asap_dev'
+          mysql user: 'asap_dev_admin'
+          mysql password: ${{ secrets.DatabasePassword }}
+
       - uses: actions/checkout@v3
       - name: Set up JDK 11
         uses: actions/setup-java@v3

--- a/.github/workflows/prod-ci.yml
+++ b/.github/workflows/prod-ci.yml
@@ -13,14 +13,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Setup MySQL
-        uses: samin/mysql-action@v1
-        with:
-          character set server: 'utf8'
-          mysql database: 'asap_dev'
-          mysql user: 'asap_dev_admin'
-          mysql password: ${{ secrets.DatabasePassword }}
-
       - uses: actions/checkout@v3
       - name: Set up JDK 11
         uses: actions/setup-java@v3

--- a/.github/workflows/prod-ci.yml
+++ b/.github/workflows/prod-ci.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: mirromutth/mysql-action@v1.1
+      - name: Setup MySQL
+        uses: samin/mysql-action@v1
         with:
-          host port: 3306
-          container port: 3306
+          character set server: 'utf8'
           mysql database: 'asap_dev'
           mysql user: 'asap_dev_admin'
           mysql password: ${{ secrets.DatabasePassword }}

--- a/.github/workflows/prod-ci.yml
+++ b/.github/workflows/prod-ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
 
       - name: make application.properties 파일 생성

--- a/src/main/java/com/asap/server/common/utils/BestMeetingUtil.java
+++ b/src/main/java/com/asap/server/common/utils/BestMeetingUtil.java
@@ -40,7 +40,10 @@ public class BestMeetingUtil {
     private List<BestMeetingTimeVo> findAllBestMeetingTimes(final List<TimeBlocksByDateVo> timeBlocksByDates, final List<PossibleTimeCaseVo> timeCases) {
         List<BestMeetingTimeVo> bestMeetingTimes = new ArrayList<>();
         for (PossibleTimeCaseVo timeCase : timeCases) {
-            List<BestMeetingTimeVo> bestMeetingTimesWithTimeCase = findBestMeetingTimesWithTimeCase(timeCase, timeBlocksByDates);
+            List<BestMeetingTimeVo> bestMeetingTimesWithTimeCase =
+                    findBestMeetingTimesWithTimeCase(timeCase, timeBlocksByDates).stream()
+                            .sorted(Comparator.comparing(BestMeetingTimeVo::weight, Comparator.reverseOrder()))
+                            .toList();
             bestMeetingTimes.addAll(bestMeetingTimesWithTimeCase);
 
             if (bestMeetingTimes.size() < BEST_MEETING_TIME_SIZE) continue;
@@ -62,7 +65,6 @@ public class BestMeetingUtil {
 
     private List<BestMeetingTimeVo> findTop3BestMeetingTimesSortByWeight(final List<BestMeetingTimeVo> bestMeetingTimes) {
         return bestMeetingTimes.stream()
-                .sorted(Comparator.comparing(BestMeetingTimeVo::weight, Comparator.reverseOrder()))
                 .limit(BEST_MEETING_TIME_SIZE)
                 .collect(Collectors.toList());
     }

--- a/src/test/java/com/asap/server/common/utils/GetBestMeetingTimeTest.java
+++ b/src/test/java/com/asap/server/common/utils/GetBestMeetingTimeTest.java
@@ -218,4 +218,31 @@ public class GetBestMeetingTimeTest {
         // then
         assertThat(bestMeetingTimes).isEqualTo(Arrays.asList(result, null, null));
     }
+
+    @Test
+    @DisplayName("가중치가 3인 최적의 회의 시간이 1개이고, 가중치가 4인 차선의 회의 시간이 4개일 때 (최적의 회의 시간 , 차선의 회의 시간 2개) 순으로 반환한다.")
+    public void getBestMeetingTime7() {
+        // given
+        LocalDate meetingDate = LocalDate.of(2023, 7, 10);
+
+        TimeBlockVo timeBlockByMeetingDate = new TimeBlockVo(3, SLOT_12_00, 3L);
+        TimeBlockVo timeBlock2ByMeetingDate = new TimeBlockVo(4, SLOT_12_30, 2L);
+        TimeBlockVo timeBlock3ByMeetingDate = new TimeBlockVo(4, SLOT_13_00, 2L);
+        TimeBlockVo timeBlock4ByMeetingDate = new TimeBlockVo(4, SLOT_13_30, 2L);
+        TimeBlockVo timeBlock5ByMeetingDate = new TimeBlockVo(4, SLOT_14_00, 2L);
+        List<TimeBlockVo> timeBlocks = new ArrayList<>(Arrays.asList(timeBlockByMeetingDate, timeBlock2ByMeetingDate, timeBlock3ByMeetingDate, timeBlock4ByMeetingDate, timeBlock5ByMeetingDate));
+
+        TimeBlocksByDateVo timeBlocksByDate = new TimeBlocksByDateVo(1L, meetingDate, timeBlocks);
+        List<TimeBlocksByDateVo> timeBlocksByDates = Arrays.asList(timeBlocksByDate);
+
+        BestMeetingTimeVo result = new BestMeetingTimeVo(1L, meetingDate, SLOT_12_00, SLOT_12_30, 3);
+        BestMeetingTimeVo result2 = new BestMeetingTimeVo(1L, meetingDate, SLOT_12_30, SLOT_13_00, 4);
+        BestMeetingTimeVo result3 = new BestMeetingTimeVo(1L, meetingDate, SLOT_13_00, SLOT_13_30, 4);
+
+        // when
+        List<BestMeetingTimeVo> bestMeetingTimes = bestMeetingUtil.getBestMeetingTime(timeBlocksByDates, Duration.HALF, 3);
+
+        // then
+        assertThat(bestMeetingTimes).isEqualTo(Arrays.asList(result, result2, result3));
+    }
 }

--- a/src/test/java/com/asap/server/repository/MeetingRepositoryCustomTest.java
+++ b/src/test/java/com/asap/server/repository/MeetingRepositoryCustomTest.java
@@ -23,46 +23,46 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 @Import(QueryDslConfig.class)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class MeetingRepositoryCustomTest {
-//    @Autowired
-//    private MeetingRepository meetingRepository;
-//
-//    @Autowired
-//    private EntityManager em;
-//
-//    @Test
-//    @DisplayName("방장이 로그인을 할 때, 방장 정보도 함께 불러온다.")
-//    void fetchJoinTest() {
-//        final Place place = Place.builder()
-//                .placeType(PlaceType.OFFLINE)
-//                .build();
-//
-//        final Meeting meeting = Meeting.builder()
-//                .title("회의 테스트")
-//                .password("0000")
-//                .additionalInfo("")
-//                .duration(Duration.HALF)
-//                .place(place)
-//                .build();
-//
-//        final User user = User.builder()
-//                .meeting(meeting)
-//                .name("강원용")
-//                .role(Role.HOST)
-//                .isFixed(false)
-//                .build();
-//        meeting.setHost(user);
-//
-//        em.persist(meeting);
-//        em.persist(user);
-//        em.flush();
-//        em.clear();
-//
-//        // when
-//        Meeting result = meetingRepository.findByIdWithHost(meeting.getId()).get();
-//        User host = result.getHost();
-//
-//        // then
-//        assertThat(host).isNotNull();
-//    }
+    @Autowired
+    private MeetingRepository meetingRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    @Test
+    @DisplayName("방장이 로그인을 할 때, 방장 정보도 함께 불러온다.")
+    void fetchJoinTest() {
+        final Place place = Place.builder()
+                .placeType(PlaceType.OFFLINE)
+                .build();
+
+        final Meeting meeting = Meeting.builder()
+                .title("회의 테스트")
+                .password("0000")
+                .additionalInfo("")
+                .duration(Duration.HALF)
+                .place(place)
+                .build();
+
+        final User user = User.builder()
+                .meeting(meeting)
+                .name("강원용")
+                .role(Role.HOST)
+                .isFixed(false)
+                .build();
+        meeting.setHost(user);
+
+        em.persist(meeting);
+        em.persist(user);
+        em.flush();
+        em.clear();
+
+        // when
+        Meeting result = meetingRepository.findByIdWithHost(meeting.getId()).get();
+        User host = result.getHost();
+
+        // then
+        assertThat(host).isNotNull();
+    }
 
 }

--- a/src/test/java/com/asap/server/service/meeting/ConfirmMeetingMethodTest.java
+++ b/src/test/java/com/asap/server/service/meeting/ConfirmMeetingMethodTest.java
@@ -24,57 +24,57 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 @SpringBootTest
 @Transactional
 public class ConfirmMeetingMethodTest {
-//    @Autowired
-//    private MeetingService meetingService;
-//    @Autowired
-//    private EntityManager em;
-//
-//    @Test
-//    @DisplayName("회의 확정시 ConfirmedDateTime 은 Update 된다.")
-//    void setConfirmDateTimeTest() {
-//        // given
-//        final Place place = Place.builder()
-//                .placeType(PlaceType.OFFLINE)
-//                .build();
-//        final Meeting meeting = Meeting.builder()
-//                .title("회의 테스트")
-//                .password("0000")
-//                .additionalInfo("")
-//                .duration(Duration.HALF)
-//                .place(place)
-//                .build();
-//        final User user = User.builder()
-//                .meeting(meeting)
-//                .name("강원용")
-//                .role(Role.HOST)
-//                .isFixed(false)
-//                .build();
-//        meeting.setHost(user);
-//
-//        em.persist(meeting);
-//        em.persist(user);
-//        em.flush();
-//        em.clear();
-//
-//        final UserRequestDto userDto = UserRequestDto.builder()
-//                .id(user.getId())
-//                .name(user.getName())
-//                .build();
-//        final MeetingConfirmRequestDto body = MeetingConfirmRequestDto.builder()
-//                .month("09")
-//                .day("07")
-//                .dayOfWeek("월")
-//                .startTime(TimeSlot.SLOT_6_00)
-//                .endTime(TimeSlot.SLOT_6_30)
-//                .users(List.of(userDto))
-//                .build();
-//
-//        // when
-//        meetingService.confirmMeeting(body, meeting.getId(), user.getId());
-//
-//        // then
-//        final Meeting result = em.find(Meeting.class, meeting.getId());
-//        assertThat(result.isConfirmedMeeting()).isTrue();
-//    }
+    @Autowired
+    private MeetingService meetingService;
+    @Autowired
+    private EntityManager em;
+
+    @Test
+    @DisplayName("회의 확정시 ConfirmedDateTime 은 Update 된다.")
+    void setConfirmDateTimeTest() {
+        // given
+        final Place place = Place.builder()
+                .placeType(PlaceType.OFFLINE)
+                .build();
+        final Meeting meeting = Meeting.builder()
+                .title("회의 테스트")
+                .password("0000")
+                .additionalInfo("")
+                .duration(Duration.HALF)
+                .place(place)
+                .build();
+        final User user = User.builder()
+                .meeting(meeting)
+                .name("강원용")
+                .role(Role.HOST)
+                .isFixed(false)
+                .build();
+        meeting.setHost(user);
+
+        em.persist(meeting);
+        em.persist(user);
+        em.flush();
+        em.clear();
+
+        final UserRequestDto userDto = UserRequestDto.builder()
+                .id(user.getId())
+                .name(user.getName())
+                .build();
+        final MeetingConfirmRequestDto body = MeetingConfirmRequestDto.builder()
+                .month("09")
+                .day("07")
+                .dayOfWeek("월")
+                .startTime(TimeSlot.SLOT_6_00)
+                .endTime(TimeSlot.SLOT_6_30)
+                .users(List.of(userDto))
+                .build();
+
+        // when
+        meetingService.confirmMeeting(body, meeting.getId(), user.getId());
+
+        // then
+        final Meeting result = em.find(Meeting.class, meeting.getId());
+        assertThat(result.isConfirmedMeeting()).isTrue();
+    }
 
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #250 

## Key Changes 🔑
1. 내용
   -  최적의 회의 시간대의 가중치가 차선의 회의 시간대의 가중치 보다 낮을 때 발생하는 오류 해결

## To Reviewers 📢
회의 시간이 30분이며, 회의 참여자가 3명일 때
(9:00 - 9:30 , 3명, 가중치 3) , (9:30 - 10:00 , 2명, 가중치 4), (10:30 - 11:00 , 2명, 가중치 4), (11:30 - 12:00 , 3명, 가중치 4) 
위 4가지 회의 시간이 있을 때,
(9:00 - 9:30 , 3명, 가중치 3) , (9:30 - 10:00 , 2명, 가중치 4), (10:30 - 11:00 , 2명, 가중치 4) 반환되어야 하지만
(9:30 - 10:00 , 2명, 가중치 4), (10:30 - 11:00 , 2명, 가중치 4), (11:30 - 12:00 , 3명, 가중치 4) 반환되고 있는 것을 파악했다.

회의 시간대의 가중치를 기준으로 정렬하는 로직을 수정하며 오류를 해결했다.
