### PR TITLE
#256 [fix] 종료시각 ordinal에서 1 제거

### DIFF
--- a/src/main/java/com/asap/server/service/UserService.java
+++ b/src/main/java/com/asap/server/service/UserService.java
@@ -191,7 +191,7 @@ public class UserService {
 
     private BestMeetingTimeWithUsersVo getBestMeetingTimeInUsers(final BestMeetingTimeVo bestMeetingTime) {
         if (bestMeetingTime == null) return null;
-        List<TimeSlot> timeSlots = TimeSlot.getTimeSlots(bestMeetingTime.startTime().ordinal(), bestMeetingTime.endTime().ordinal());
+        List<TimeSlot> timeSlots = TimeSlot.getTimeSlots(bestMeetingTime.startTime().ordinal(), bestMeetingTime.endTime().ordinal() - 1);
         List<UserVo> users = userRepository.findByAvailableDateAndTimeSlots(bestMeetingTime.availableDateId(), timeSlots);
         return BestMeetingTimeWithUsersVo.of(bestMeetingTime, users);
     }


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #256 

## Key Changes 🔑
1. 내용
   - 회의 시간이 1시간이고 최적의 시간이 22:00시 부터 1시간일 때 알고리즘에서 22:00 ~ 23:00를 반환합니다.
   그래서 쿼리 문에 timeSlots in (22:00, 22:30, 23:00) 이 들어가게 됩니다.
   하지만 22시부터 1시간의 정보는 22:00, 22:30 이기 때문에 23:00는 없어야 됩니다.
   그래서 time slot 목록을 구할 때 end time ordinal을 1을 제거해서 timeslot 목록을 반환받습니다.
