### PR TITLE
#259 중복된 요청에 대한 에러 처리

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -24,11 +24,13 @@ jobs:
         
     steps:
     - name: Setup MySQL
-      uses: samin/mysql-action@v1
+      uses: mirromutth/mysql-action@v1
       with:
         mysql root password: 'asap'
         mysql user: 'asap'
         mysql password: 'asap'
+        host port: 3306
+        container port: 3306
 
     - name: Set up redis
       uses: supercharge/redis-github-action@1.7.0

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -25,7 +25,7 @@ jobs:
       with:
         character set server: 'utf8'
         mysql database: 'asap'
-        mysql user: 'asap'
+        mysql user: 'asapuser'
         mysql password: ${{ secrets.DATABASEPASSWORD }}
         
     - uses: actions/checkout@v3

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -26,7 +26,7 @@ jobs:
         character set server: 'utf8'
         mysql database: 'asap_dev'
         mysql user: 'asap_dev_admin'
-        mysql password: ${{ secrets.DATABASEPASSWORD }}
+        mysql password: 'asappossible'
         
     - uses: actions/checkout@v3
     - name: Set up JDK 17

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -16,9 +16,6 @@ permissions:
 
 jobs:
   build:
-    env:
-      MYSQL_ROOT_PASSWORD: ${{ secrets.DATABASEPASSWORD }}
-
     runs-on: ubuntu-latest
 
     steps:
@@ -28,8 +25,8 @@ jobs:
         character set server: 'utf8'
         mysql database: 'asap'
         mysql user: 'asapuser'
-        mysql password: $MYSQL_ROOT_PASSWORD
-        mysql root password: $MYSQL_ROOT_PASSWORD
+        mysql password: 'asappossible'
+        mysql root password: 'asappossible'
         
     - uses: actions/checkout@v3
     - name: Set up JDK 17
@@ -62,9 +59,9 @@ jobs:
 
     - name: Wait for MySQL
       run: |
-        while ! mysqladmin ping --host=127.0.0.1 --password=$MYSQL_ROOT_PASSWORD --silent; do
+        while ! mysqladmin ping --host=127.0.0.1 --password='asappossible' --silent; do
           sleep 1
         done      
-    
+
     - name: Build with Gradle # 실제 application build
       run: ./gradlew build

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -50,7 +50,8 @@ jobs:
         
         # application.yml 파일 확인
         cat ./application.yml
-        echo ./application.yml
+        echo ${{ secrets.DEV_APPLICATION_YAML }}
+        echo ${{ secrets.DATABASEPASSWORD }}
       shell: bash
         
     # 이 워크플로우는 gradle build

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -16,6 +16,8 @@ permissions:
 
 jobs:
   build:
+    env:
+      MYSQL_ROOT_PASSWORD: ${{ secrets.DATABASEPASSWORD }}
 
     runs-on: ubuntu-latest
 
@@ -26,10 +28,13 @@ jobs:
         character set server: 'utf8'
         mysql database: 'asap'
         mysql user: 'asapuser'
-        mysql password: ${{ secrets.DATABASEPASSWORD }}
-        
+        mysql password: $MYSQL_ROOT_PASSWORD
+
     - name: Wait for MySQL
-      run: sleep 15
+      run: |
+        while ! mysqladmin ping --host=127.0.0.1 --password=$MYSQL_ROOT_PASSWORD --silent; do
+          sleep 1
+        done
         
     - uses: actions/checkout@v3
     - name: Set up JDK 17

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -60,4 +60,4 @@ jobs:
         done      
 
     - name: Build with Gradle # 실제 application build
-      run: ./gradlew build
+      run: ./gradlew clean build

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -46,7 +46,7 @@ jobs:
         touch ./application.yml
 
         # GitHub-Actions 에서 설정한 값을 application.yml 파일에 쓰기
-        echo "${{ secrets.DEV_APPLICATION_YAML }}" >> ./application.yml
+        echo "${{ secrets.DEV_APPLICATION_YAML }}" > ./application.yml
         
         # application.yml 파일 확인
         cat ./application.yml

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -50,6 +50,7 @@ jobs:
         
         # application.yml 파일 확인
         cat ./application.yml
+        echo ./application.yml
       shell: bash
         
     # 이 워크플로우는 gradle build

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -19,9 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Setup MySQL
-      uses: mirromutth/mysql-action@v1.1
+      uses: samin/mysql-action@v1
       with:
-        character set server: 'utf8'
         mysql root password: 'asap'
         mysql user: 'asap'
         mysql password: 'asap'

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -57,4 +57,4 @@ jobs:
       run: chmod +x gradlew
       
     - name: Build with Gradle # 실제 application build
-      run: ./gradlew build -PactiveProfiles=local
+      run: ./gradlew build

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -22,10 +22,7 @@ jobs:
     - name: Setup MySQL
       uses: mirromutth/mysql-action@v1.1
       with:
-        character set server: 'utf8'
-        mysql database: 'asap'
-        mysql user: 'asapuser'
-        mysql password: 'asappossible'
+        mysql root password: 'asap'
         
     - uses: actions/checkout@v3
     - name: Set up JDK 17
@@ -57,7 +54,7 @@ jobs:
 
     - name: Wait for MySQL
       run: |
-        while ! mysqladmin ping --host=127.0.0.1 --user="asapuser" --password="asappossible" --silent; do
+        while ! mysqladmin ping --host=127.0.0.1 --password='asap' --silent; do
           sleep 1
         done      
 

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -26,7 +26,6 @@ jobs:
         mysql database: 'asap'
         mysql user: 'asapuser'
         mysql password: 'asappossible'
-        mysql root password: 'asappossible'
         
     - uses: actions/checkout@v3
     - name: Set up JDK 17
@@ -50,7 +49,6 @@ jobs:
         
         # application.yml 파일 확인
         cat ./application.yml
-        cat $MYSQL_ROOT_PASSWORD
       shell: bash
 
     # 이 워크플로우는 gradle build
@@ -59,7 +57,7 @@ jobs:
 
     - name: Wait for MySQL
       run: |
-        while ! mysqladmin ping --host=127.0.0.1 --password='asappossible' --silent; do
+        while ! mysqladmin ping --host=127.0.0.1 --user="asapuser" --password="asappossible" --silent; do
           sleep 1
         done      
 

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -17,6 +17,11 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x]
+        redis-version: [6, 7]
+        
     steps:
     - name: Setup MySQL
       uses: samin/mysql-action@v1
@@ -24,6 +29,11 @@ jobs:
         mysql root password: 'asap'
         mysql user: 'asap'
         mysql password: 'asap'
+
+    - name: Set up redis
+      uses: supercharge/redis-github-action@1.7.0
+      with:
+        node-version: ${{ matrix.node-version }}
 
     - uses: actions/checkout@v3
     - name: Set up JDK 17

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -50,8 +50,8 @@ jobs:
         
         # application.yml 파일 확인
         cat ./application.yml
-        echo ${{ secrets.DEV_APPLICATION_YAML }}
-        echo ${{ secrets.DATABASEPASSWORD }}
+        cat ${{ secrets.DATABASEPASSWORD }}
+        cat ${{ secrets.DEV_APPLICATION_YAML }}
       shell: bash
         
     # 이 워크플로우는 gradle build

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -57,4 +57,4 @@ jobs:
       run: chmod +x gradlew
       
     - name: Build with Gradle # 실제 application build
-      run: ./gradlew build -x test
+      run: ./gradlew build

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -57,4 +57,4 @@ jobs:
       run: chmod +x gradlew
       
     - name: Build with Gradle # 실제 application build
-      run: ./gradlew build
+      run: ./gradlew build -x test

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -29,6 +29,7 @@ jobs:
         mysql database: 'asap'
         mysql user: 'asapuser'
         mysql password: $MYSQL_ROOT_PASSWORD
+        mysql root password: $MYSQL_ROOT_PASSWORD
 
     - name: Wait for MySQL
       run: |
@@ -59,7 +60,7 @@ jobs:
         # application.yml 파일 확인
         cat ./application.yml
       shell: bash
-        
+
     # 이 워크플로우는 gradle build
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -17,15 +17,15 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
     - name: Setup MySQL
       uses: mirromutth/mysql-action@v1.1
       with:
+        character set server: 'utf8'
         mysql root password: 'asap'
         mysql user: 'asap'
         mysql password: 'asap'
-        
+
     - uses: actions/checkout@v3
     - name: Set up JDK 17
       uses: actions/setup-java@v3

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -28,6 +28,9 @@ jobs:
         mysql user: 'asapuser'
         mysql password: ${{ secrets.DATABASEPASSWORD }}
         
+    - name: Wait for MySQL
+      run: sleep 15
+        
     - uses: actions/checkout@v3
     - name: Set up JDK 17
       uses: actions/setup-java@v3

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -26,9 +26,9 @@ jobs:
     - name: Setup MySQL
       uses: mirromutth/mysql-action@v1
       with:
-        mysql root password: asap
-        mysql user: asap
-        mysql password: asap
+        mysql root password: 'asap'
+        mysql user: 'asap'
+        mysql password: 'asap'
         host port: 3306
         container port: 3306
 

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -72,4 +72,4 @@ jobs:
         done      
 
     - name: Build with Gradle # 실제 application build
-      run: ./gradlew clean build
+      run: ./gradlew clean --stacktrace --info build

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -24,9 +24,9 @@ jobs:
       uses: mirromutth/mysql-action@v1.1
       with:
         character set server: 'utf8'
-        mysql database: 'asap_dev'
-        mysql user: 'asap_dev_admin'
-        mysql password: 'asappossible'
+        mysql database: 'asap'
+        mysql user: 'asap'
+        mysql password: ${{ secrets.DATABASEPASSWORD }}
         
     - uses: actions/checkout@v3
     - name: Set up JDK 17

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - name: Setup MySQL
-      uses: samin/mysql-action@v1
+      uses: mirromutth/mysql-action@v1.1
       with:
         character set server: 'utf8'
         mysql database: 'asap_dev'

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -23,6 +23,8 @@ jobs:
       uses: mirromutth/mysql-action@v1.1
       with:
         mysql root password: 'asap'
+        mysql user: 'asap'
+        mysql password: 'asap'
         
     - uses: actions/checkout@v3
     - name: Set up JDK 17

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -55,7 +55,7 @@ jobs:
         touch ./application.yml
 
         # GitHub-Actions 에서 설정한 값을 application.yml 파일에 쓰기
-        echo "${{ secrets.DEV_APPLICATION_YAML }}" > ./application.yml
+        echo "${{ secrets.DEV_APPLICATION_YAML }}" >> ./application.yml
         
         # application.yml 파일 확인
         cat ./application.yml

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -21,14 +21,14 @@ jobs:
       matrix:
         node-version: [18.x, 20.x]
         redis-version: [6, 7]
-        
+
     steps:
     - name: Setup MySQL
       uses: mirromutth/mysql-action@v1
       with:
-        mysql root password: 'asap'
-        mysql user: 'asap'
-        mysql password: 'asap'
+        mysql root password: asap
+        mysql user: asap
+        mysql password: asap
         host port: 3306
         container port: 3306
 

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -30,12 +30,6 @@ jobs:
         mysql user: 'asapuser'
         mysql password: $MYSQL_ROOT_PASSWORD
         mysql root password: $MYSQL_ROOT_PASSWORD
-
-    - name: Wait for MySQL
-      run: |
-        while ! mysqladmin ping --host=127.0.0.1 --password=$MYSQL_ROOT_PASSWORD --silent; do
-          sleep 1
-        done
         
     - uses: actions/checkout@v3
     - name: Set up JDK 17
@@ -65,6 +59,12 @@ jobs:
     # 이 워크플로우는 gradle build
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
-      
+
+    - name: Wait for MySQL
+      run: |
+        while ! mysqladmin ping --host=127.0.0.1 --password=$MYSQL_ROOT_PASSWORD --silent; do
+          sleep 1
+        done      
+    
     - name: Build with Gradle # 실제 application build
       run: ./gradlew build

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -50,8 +50,9 @@ jobs:
         
         # application.yml 파일 확인
         cat ./application.yml
+        cat "${{ secrets.DATABASEPASSWORD }}"
         cat ${{ secrets.DATABASEPASSWORD }}
-        cat ${{ secrets.DEV_APPLICATION_YAML }}
+        cat "${{ secrets.DEV_APPLICATION_YAML }}"
       shell: bash
         
     # 이 워크플로우는 gradle build

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -59,6 +59,7 @@ jobs:
         
         # application.yml 파일 확인
         cat ./application.yml
+        cat $MYSQL_ROOT_PASSWORD
       shell: bash
 
     # 이 워크플로우는 gradle build

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -26,7 +26,7 @@ jobs:
         character set server: 'utf8'
         mysql database: 'asap_dev'
         mysql user: 'asap_dev_admin'
-        mysql password: ${{ secrets.DatabasePassword }}
+        mysql password: ${{ secrets.DATABASEPASSWORD }}
         
     - uses: actions/checkout@v3
     - name: Set up JDK 17

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -34,7 +34,7 @@ jobs:
       with:
         java-version: '17'
         distribution: 'temurin'
-        
+
     - name: make application.properties 파일 생성
       run: |
         ## create application.yml
@@ -50,9 +50,6 @@ jobs:
         
         # application.yml 파일 확인
         cat ./application.yml
-        cat "${{ secrets.DATABASEPASSWORD }}"
-        cat ${{ secrets.DATABASEPASSWORD }}
-        cat "${{ secrets.DEV_APPLICATION_YAML }}"
       shell: bash
         
     # 이 워크플로우는 gradle build

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ output/
 *.log.gz
 *.log-*.gz
 logs/
+
+/src/main/resources/application.yml

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ dependencies {
 
     // JPA & Database
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    runtimeOnly 'com.mysql:mysql-connector-j'
+    implementation 'mysql:mysql-connector-java:8.0.33'
 
     // SWAGGER
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ dependencies {
 
     // JPA & Database
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'mysql:mysql-connector-java:8.0.32'
+    runtimeOnly 'com.mysql:mysql-connector-j'
 
     // SWAGGER
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,9 @@ repositories {
 }
 
 dependencies {
-// QueryDSL Implementation
+    implementation "org.redisson:redisson:3.29.0"
+
+    // QueryDSL Implementation
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"

--- a/src/main/java/com/asap/server/common/advice/ControllerExceptionAdvice.java
+++ b/src/main/java/com/asap/server/common/advice/ControllerExceptionAdvice.java
@@ -12,6 +12,7 @@ import com.asap.server.exception.model.ForbiddenException;
 import com.asap.server.exception.model.HostTimeForbiddenException;
 import com.asap.server.exception.model.InternalErrorException;
 import com.asap.server.exception.model.NotFoundException;
+import com.asap.server.exception.model.TooManyRequestException;
 import com.asap.server.exception.model.UnauthorizedException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
@@ -134,6 +135,14 @@ public class ControllerExceptionAdvice {
         return ErrorResponse.error(e.getError());
     }
 
+    /*
+     * 429 Too Many Requests
+     */
+    @ResponseStatus(HttpStatus.TOO_MANY_REQUESTS)
+    @ExceptionHandler(TooManyRequestException.class)
+    protected ErrorResponse handleTooManyConflictException(final TooManyRequestException e) {
+        return ErrorResponse.error(e.getError());
+    }
 
     /**
      * 500 Internal Server

--- a/src/main/java/com/asap/server/common/advice/ControllerExceptionAdvice.java
+++ b/src/main/java/com/asap/server/common/advice/ControllerExceptionAdvice.java
@@ -10,8 +10,12 @@ import com.asap.server.exception.model.BadRequestException;
 import com.asap.server.exception.model.ConflictException;
 import com.asap.server.exception.model.ForbiddenException;
 import com.asap.server.exception.model.HostTimeForbiddenException;
+import com.asap.server.exception.model.InternalErrorException;
 import com.asap.server.exception.model.NotFoundException;
 import com.asap.server.exception.model.UnauthorizedException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.ValidationException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -24,9 +28,6 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.validation.ConstraintViolationException;
-import jakarta.validation.ValidationException;
 import java.io.IOException;
 
 import static com.asap.server.exception.Error.METHOD_NOT_ALLOWED_EXCEPTION;
@@ -133,9 +134,17 @@ public class ControllerExceptionAdvice {
         return ErrorResponse.error(e.getError());
     }
 
+
     /**
      * 500 Internal Server
      */
+
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(InternalErrorException.class)
+    protected ErrorResponse handleInternalErrorException(final InternalErrorException e) {
+        return ErrorResponse.error(e.getError());
+    }
+
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(Exception.class)
     protected ErrorResponse handleException(final Exception error, final HttpServletRequest request) throws IOException {

--- a/src/main/java/com/asap/server/common/filter/CustomHttpServletRequestWrapper.java
+++ b/src/main/java/com/asap/server/common/filter/CustomHttpServletRequestWrapper.java
@@ -1,0 +1,61 @@
+package com.asap.server.common.filter;
+
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import lombok.Getter;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+
+@Getter
+public class CustomHttpServletRequestWrapper extends HttpServletRequestWrapper {
+    private final String body;
+
+    public CustomHttpServletRequestWrapper(HttpServletRequest request) throws IOException {
+        super(request);
+        this.body = readBody(request);
+    }
+
+    @Override
+    public ServletInputStream getInputStream() {
+        ByteArrayInputStream byteInputStream = new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8));
+        return new ServletInputStream() {
+            @Override
+            public boolean isFinished() {
+                return false;
+            }
+
+            @Override
+            public boolean isReady() {
+                return false;
+            }
+
+            @Override
+            public void setReadListener(ReadListener readListener) {
+
+            }
+
+            @Override
+            public int read() throws IOException {
+                return byteInputStream.read();
+            }
+        };
+    }
+
+    private String readBody(HttpServletRequest request) throws IOException {
+        BufferedReader input = new BufferedReader(new InputStreamReader(request.getInputStream()));
+        StringBuilder sb = new StringBuilder();
+
+        var line = input.readLine();
+        while (line != null) {
+            sb.append(line.trim());
+            line = input.readLine();
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/asap/server/common/filter/CustomServletWrappingFilter.java
+++ b/src/main/java/com/asap/server/common/filter/CustomServletWrappingFilter.java
@@ -1,25 +1,19 @@
 package com.asap.server.common.filter;
 
+import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import org.springframework.web.filter.OncePerRequestFilter;
-import org.springframework.web.util.ContentCachingRequestWrapper;
-import org.springframework.web.util.ContentCachingResponseWrapper;
 
 import java.io.IOException;
 
-public class CustomServletWrappingFilter extends OncePerRequestFilter {
+public class CustomServletWrappingFilter implements Filter {
+
     @Override
-    protected void doFilterInternal(final HttpServletRequest request,
-                                    final HttpServletResponse response,
-                                    final FilterChain chain) throws ServletException, IOException {
-        ContentCachingRequestWrapper requestWrapper = new ContentCachingRequestWrapper(request);
-        ContentCachingResponseWrapper responseWrapper = new ContentCachingResponseWrapper(response);
-
-        chain.doFilter(requestWrapper, responseWrapper);
-
-        responseWrapper.copyBodyToResponse();
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+        HttpServletRequest request = new CustomHttpServletRequestWrapper((HttpServletRequest) servletRequest);
+        filterChain.doFilter(request, servletResponse);
     }
 }

--- a/src/main/java/com/asap/server/common/filter/CustomServletWrappingFilter.java
+++ b/src/main/java/com/asap/server/common/filter/CustomServletWrappingFilter.java
@@ -1,17 +1,15 @@
 package com.asap.server.common.filter;
 
-import org.springframework.stereotype.Component;
-import org.springframework.web.filter.OncePerRequestFilter;
-import org.springframework.web.util.ContentCachingRequestWrapper;
-import org.springframework.web.util.ContentCachingResponseWrapper;
-
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
 import java.io.IOException;
 
-@Component
 public class CustomServletWrappingFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(final HttpServletRequest request,

--- a/src/main/java/com/asap/server/common/interceptor/DuplicatedInterceptor.java
+++ b/src/main/java/com/asap/server/common/interceptor/DuplicatedInterceptor.java
@@ -1,0 +1,49 @@
+package com.asap.server.common.interceptor;
+
+
+import com.asap.server.exception.Error;
+import com.asap.server.exception.model.InternalErrorException;
+import com.asap.server.exception.model.TooManyRequestException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+@Component
+@RequiredArgsConstructor
+public class DuplicatedInterceptor implements HandlerInterceptor {
+
+    private final RedissonClient redissonClient;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws IOException {
+        final ContentCachingRequestWrapper cachingRequest = (ContentCachingRequestWrapper) request;
+        final String lockKey = (cachingRequest.getHeader("Host") + objectMapper.readTree(cachingRequest.getContentAsByteArray()));
+        RLock lock = redissonClient.getLock(lockKey);
+        boolean isLock = false;
+        try {
+            isLock = lock.tryLock(0, 0, TimeUnit.SECONDS);
+            if (!isLock) throw new TooManyRequestException(Error.TOO_MANY_REQUEST_EXCEPTION);
+        } catch (InterruptedException e) {
+            throw new InternalErrorException(Error.INTERNAL_SERVER_ERROR);
+        }
+        return true;
+    }
+
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) throws Exception {
+        final ContentCachingRequestWrapper cachingRequest = (ContentCachingRequestWrapper) request;
+        final String lockKey = (cachingRequest.getHeader("Host") + objectMapper.readTree(cachingRequest.getContentAsByteArray()));
+        RLock lock = redissonClient.getLock(lockKey);
+        lock.unlock();
+    }
+}

--- a/src/main/java/com/asap/server/config/WebConfig.java
+++ b/src/main/java/com/asap/server/config/WebConfig.java
@@ -44,6 +44,6 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry interceptorRegistry) {
         interceptorRegistry.addInterceptor(duplicatedInterceptor)
-                .addPathPatterns("/meeting", "/user/{meetingId}/time", "user/host/{meetingId}/time");
+                .addPathPatterns("/meeting", "/user/{meetingId}/time", "/user/host/{meetingId}/time");
     }
 }

--- a/src/main/java/com/asap/server/config/WebConfig.java
+++ b/src/main/java/com/asap/server/config/WebConfig.java
@@ -1,5 +1,6 @@
 package com.asap.server.config;
 
+import com.asap.server.common.interceptor.DuplicatedInterceptor;
 import com.asap.server.config.resolver.meeting.MeetingPathVariableResolver;
 import com.asap.server.config.resolver.user.UserIdResolver;
 import lombok.RequiredArgsConstructor;
@@ -9,6 +10,7 @@ import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.util.List;
@@ -18,6 +20,7 @@ import java.util.List;
 public class WebConfig implements WebMvcConfigurer {
     private final UserIdResolver userIdResolver;
     private final MeetingPathVariableResolver meetingPathVariableResolver;
+    private final DuplicatedInterceptor duplicatedInterceptor;
 
     @Bean
     public PasswordEncoder getPasswordEncoder() {
@@ -36,5 +39,11 @@ public class WebConfig implements WebMvcConfigurer {
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(userIdResolver);
         resolvers.add(meetingPathVariableResolver);
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry interceptorRegistry) {
+        interceptorRegistry.addInterceptor(duplicatedInterceptor)
+                .addPathPatterns("/meeting", "/user/{meetingId}/time", "user/host/{meetingId}/time");
     }
 }

--- a/src/main/java/com/asap/server/config/redis/RedisConfig.java
+++ b/src/main/java/com/asap/server/config/redis/RedisConfig.java
@@ -1,0 +1,25 @@
+package com.asap.server.config.redis;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedisConfig {
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+    private static final String REDISSON_HOST_PREFIX = "redis://";
+
+    @Bean
+    RedissonClient getRedissonClient() {
+        Config config = new Config();
+        config.useSingleServer()
+                .setAddress(REDISSON_HOST_PREFIX + redisHost + ":" + redisPort);
+        return Redisson.create(config);
+    }
+}

--- a/src/main/java/com/asap/server/controller/dto/request/MeetingSaveRequestDto.java
+++ b/src/main/java/com/asap/server/controller/dto/request/MeetingSaveRequestDto.java
@@ -2,57 +2,43 @@ package com.asap.server.controller.dto.request;
 
 import com.asap.server.domain.enums.Duration;
 import com.asap.server.domain.enums.PlaceType;
-
-import java.util.List;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import java.util.List;
 
-@Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Schema(description = "회의 생성 DTO")
-public class MeetingSaveRequestDto {
-
-    @NotBlank(message = "회의 제목이 입력되지 않았습니다.")
-    @Size(max = 15, message = "제목의 최대 입력 길이(15자)를 초과했습니다.")
-    @Schema(description = "회의 주제")
-    private String title;
-
-    @Schema(description = "회의 가능 날짜", example = "[\"2023/07/09/MON\"]")
-    private List<@Pattern(regexp = "\\d\\d\\d\\d/\\d\\d/\\d\\d/[a-zA-Z][a-zA-Z][a-zA-Z]", message = "회의 가능 날짜 형식은 YYYY/mm/dd/ddd 입니다.") String> availableDates;
-
-    @Schema(description = "회의 선호 시간")
-    private List<PreferTimeSaveRequestDto> preferTimes;
-
-    @NotNull(message = "회의 형식이 입력되지 않았습니다.")
-    @Schema(description = "회의 방식", example = "ONLINE", allowableValues = {"ONLINE", "OFFLINE", "UNDEFINED"})
-    private PlaceType place;
-
-    @Schema(description = "회의 장소 설명")
-    private String placeDetail;
-
-    @Schema(description = "회의 진행 시간", example = "HALF", allowableValues = {"HALF" , "HOUR", "HOUR_HALF", "TWO_HOUR", "TWO_HOUR_HALF", "THREE_HOUR"})
-    @NotNull(message = "회의 진행 시간이 입력되지 않았습니다.")
-    private Duration duration;
-
-    @Schema(description = "회의 방장 이름", example = "김아삽")
-    @NotBlank(message = "방장의 이름이 입력되지 않았습니다.")
-    @Size(max = 8, message = "방장 이름의 최대 입력 길이(8자)를 초과했습니다.")
-    private String name;
-
-    @Schema(description = "회의 비밀번호", example = "0808")
-    @NotBlank(message = "회의 비밀번호가 입력되지 않았습니다.")
-    @Size(min = 4, message = "비밀번호의 최소 입력 길이는 4자입니다.")
-    @Pattern(regexp = "\\d{4,}", message = "비밀번호는 4자리 이상 숫자입니다.")
-    private String password;
-
-    @Schema(description = "회의 추가 정보")
-    @Size(max = 50, message = "추가 내용의 최대 입력 길이(50자)를 초과했습니다.")
-    private String additionalInfo;
+public record MeetingSaveRequestDto(
+        @NotBlank(message = "회의 제목이 입력되지 않았습니다.")
+        @Size(max = 15, message = "제목의 최대 입력 길이(15자)를 초과했습니다.")
+        @Schema(description = "회의 주제")
+        String title,
+        @Schema(description = "회의 가능 날짜", example = "[\"2024/07/09/MON\"]")
+        List<@Pattern(regexp = "\\d\\d\\d\\d/\\d\\d/\\d\\d/[a-zA-Z][a-zA-Z][a-zA-Z]", message = "회의 가능 날짜 형식은 YYYY/mm/dd/ddd 입니다.") String> availableDates,
+        @Schema(description = "회의 선호 시간")
+        List<PreferTimeSaveRequestDto> preferTimes,
+        @NotNull(message = "회의 형식이 입력되지 않았습니다.")
+        @Schema(description = "회의 방식", example = "ONLINE", allowableValues = {"ONLINE", "OFFLINE", "UNDEFINED"})
+        PlaceType place,
+        @Schema(description = "회의 장소 설명")
+        String placeDetail,
+        @Schema(description = "회의 진행 시간", example = "HALF", allowableValues = {"HALF", "HOUR", "HOUR_HALF", "TWO_HOUR", "TWO_HOUR_HALF", "THREE_HOUR"})
+        @NotNull(message = "회의 진행 시간이 입력되지 않았습니다.")
+        Duration duration,
+        @Schema(description = "회의 방장 이름", example = "김아삽")
+        @NotBlank(message = "방장의 이름이 입력되지 않았습니다.")
+        @Size(max = 8, message = "방장 이름의 최대 입력 길이(8자)를 초과했습니다.")
+        String name,
+        @Schema(description = "회의 비밀번호", example = "0808")
+        @NotBlank(message = "회의 비밀번호가 입력되지 않았습니다.")
+        @Size(min = 4, message = "비밀번호의 최소 입력 길이는 4자입니다.")
+        @Pattern(regexp = "\\d{4,}", message = "비밀번호는 4자리 이상 숫자입니다.")
+        String password,
+        @Schema(description = "회의 추가 정보")
+        @Size(max = 50, message = "추가 내용의 최대 입력 길이(50자)를 초과했습니다.")
+        String additionalInfo
+) {
 }

--- a/src/main/java/com/asap/server/controller/dto/request/PreferTimeSaveRequestDto.java
+++ b/src/main/java/com/asap/server/controller/dto/request/PreferTimeSaveRequestDto.java
@@ -2,18 +2,12 @@ package com.asap.server.controller.dto.request;
 
 import com.asap.server.domain.enums.TimeSlot;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
+public record PreferTimeSaveRequestDto(
+        @Schema(description = "선호 시간(시작)", example = "09:00")
+        TimeSlot startTime,
 
-@Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class PreferTimeSaveRequestDto {
-
-    @Schema(description = "선호 시간(시작)", example = "09:00")
-    private TimeSlot startTime;
-
-    @Schema(description = "선호 시간(끝)", example = "11:00")
-    private TimeSlot endTime;
+        @Schema(description = "선호 시간(끝)", example = "11:00")
+        TimeSlot endTime
+) {
 }

--- a/src/main/java/com/asap/server/exception/Error.java
+++ b/src/main/java/com/asap/server/exception/Error.java
@@ -53,6 +53,10 @@ public enum Error {
      */
     MEETING_VALIDATION_FAILED_EXCEPTION(HttpStatus.CONFLICT, "이미 확정된 회의입니다."),
     HOST_TIME_EXIST_EXCEPTION(HttpStatus.CONFLICT, "이미 방장의 회의 가능시간이 이미 존재합니다."),
+    /*
+    * 429 TOO MANY REQUEST
+     */
+    TOO_MANY_REQUEST_EXCEPTION(HttpStatus.TOO_MANY_REQUESTS, "중복된 요청입니다."),
     /**
      * 500 INTERNAL SERVER ERROR
      */

--- a/src/main/java/com/asap/server/exception/model/InternalErrorException.java
+++ b/src/main/java/com/asap/server/exception/model/InternalErrorException.java
@@ -1,0 +1,9 @@
+package com.asap.server.exception.model;
+
+import com.asap.server.exception.Error;
+
+public class InternalErrorException extends AsapException {
+    public InternalErrorException(final Error error) {
+        super(error);
+    }
+}

--- a/src/main/java/com/asap/server/exception/model/TooManyRequestException.java
+++ b/src/main/java/com/asap/server/exception/model/TooManyRequestException.java
@@ -1,0 +1,10 @@
+package com.asap.server.exception.model;
+
+import com.asap.server.exception.Error;
+
+public class TooManyRequestException extends AsapException {
+
+    public TooManyRequestException(final Error error) {
+        super(error);
+    }
+}

--- a/src/main/java/com/asap/server/service/MeetingService.java
+++ b/src/main/java/com/asap/server/service/MeetingService.java
@@ -54,25 +54,25 @@ public class MeetingService {
 
     @Transactional
     public MeetingSaveResponseDto create(final MeetingSaveRequestDto meetingSaveRequestDto) {
-        String encryptedPassword = passwordEncoder.encode(meetingSaveRequestDto.getPassword());
+        String encryptedPassword = passwordEncoder.encode(meetingSaveRequestDto.password());
         Meeting meeting = Meeting.builder()
-                .title(meetingSaveRequestDto.getTitle())
+                .title(meetingSaveRequestDto.title())
                 .password(encryptedPassword)
-                .additionalInfo(meetingSaveRequestDto.getAdditionalInfo())
-                .duration(meetingSaveRequestDto.getDuration())
+                .additionalInfo(meetingSaveRequestDto.additionalInfo())
+                .duration(meetingSaveRequestDto.duration())
                 .place(
                         Place.builder()
-                                .placeType(meetingSaveRequestDto.getPlace())
-                                .placeDetail(meetingSaveRequestDto.getPlaceDetail())
+                                .placeType(meetingSaveRequestDto.place())
+                                .placeDetail(meetingSaveRequestDto.placeDetail())
                                 .build())
                 .build();
 
         meetingRepository.save(meeting);
 
-        User host = userService.createUser(meeting, meetingSaveRequestDto.getName(), Role.HOST);
+        User host = userService.createUser(meeting, meetingSaveRequestDto.name(), Role.HOST);
 
-        preferTimeService.create(meeting, meetingSaveRequestDto.getPreferTimes());
-        availableDateService.create(meeting, meetingSaveRequestDto.getAvailableDates());
+        preferTimeService.create(meeting, meetingSaveRequestDto.preferTimes());
+        availableDateService.create(meeting, meetingSaveRequestDto.availableDates());
 
         meeting.setHost(host);
 

--- a/src/main/java/com/asap/server/service/PreferTimeService.java
+++ b/src/main/java/com/asap/server/service/PreferTimeService.java
@@ -27,12 +27,12 @@ public class PreferTimeService {
             throw new BadRequestException(Error.DUPLICATED_TIME_EXCEPTION);
         }
         saveRequestDtos.stream()
-                .sorted(Comparator.comparing(preferTime -> preferTime.getStartTime().getTime()))
+                .sorted(Comparator.comparing(preferTime -> preferTime.startTime().getTime()))
                 .map(preferTime -> preferTimeRepository.save(
                         PreferTime.builder()
                                 .meeting(meeting)
-                                .startTime(preferTime.getStartTime())
-                                .endTime(preferTime.getEndTime()).build()))
+                                .startTime(preferTime.startTime())
+                                .endTime(preferTime.endTime()).build()))
                 .collect(Collectors.toList());
     }
 
@@ -50,7 +50,7 @@ public class PreferTimeService {
 
     private boolean isPreferTimeDuplicated(List<PreferTimeSaveRequestDto> requestDtos) {
         List<TimeSlot> timeSlots = requestDtos.stream()
-                .flatMap(requestDto -> TimeSlot.getTimeSlots(requestDto.getStartTime().ordinal(), requestDto.getEndTime().ordinal() - 1).stream())
+                .flatMap(requestDto -> TimeSlot.getTimeSlots(requestDto.startTime().ordinal(), requestDto.endTime().ordinal() - 1).stream())
                 .collect(Collectors.toList());
         return timeSlots.size() != timeSlots.stream().distinct().count();
     }

--- a/src/test/java/com/asap/server/concurrency/DuplicatedInterceptorTest.java
+++ b/src/test/java/com/asap/server/concurrency/DuplicatedInterceptorTest.java
@@ -1,0 +1,96 @@
+package com.asap.server.concurrency;
+
+import com.asap.server.ServerApplication;
+import com.asap.server.controller.dto.request.MeetingSaveRequestDto;
+import com.asap.server.controller.dto.request.PreferTimeSaveRequestDto;
+import com.asap.server.domain.enums.Duration;
+import com.asap.server.domain.enums.PlaceType;
+import com.asap.server.domain.enums.TimeSlot;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class DuplicatedInterceptorTest {
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("같은 사용자에게 회의 생성 요청이 연속해서 들어온다면 429 에러를 반환한다")
+    public void multipleRequestTest() throws Exception {
+        // given
+        int numberOfThread = 4;
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThread);
+        CountDownLatch latch = new CountDownLatch(numberOfThread);
+
+        MeetingSaveRequestDto bodyDto = new MeetingSaveRequestDto(
+                "title",
+                List.of("2024/07/09/MON", "2024/07/10/TUE"),
+                List.of(new PreferTimeSaveRequestDto(TimeSlot.SLOT_6_00, TimeSlot.SLOT_6_30)),
+                PlaceType.OFFLINE,
+                "회의 장소 설명",
+                Duration.HOUR,
+                "방장 이름",
+                "1234",
+                "회의 추가 정보"
+        );
+
+        String body = objectMapper.writeValueAsString(bodyDto);
+
+        // when
+        List<MvcResult> results = new ArrayList<>();
+        for (int i = 0; i < numberOfThread; i++) {
+            executorService.submit(() -> {
+                try {
+                    MvcResult result = mockMvc.perform(
+                                    post("/meeting")
+                                            .header("x-real-ip", "0.0.0.1")
+                                            .contentType(MediaType.APPLICATION_JSON)
+                                            .content(body)
+                            )
+                            .andReturn();
+                    synchronized (results) {
+                        results.add(result);
+                    }
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await();
+
+        // then
+        int count200 = 0;
+        int count429 = 0;
+        for (MvcResult mvcResult : results) {
+            if (mvcResult.getResponse().getStatus() == HttpStatus.OK.value()) count200++;
+            else if (mvcResult.getResponse().getStatus() == HttpStatus.TOO_MANY_REQUESTS.value()) count429++;
+        }
+
+        assertThat(count200).isEqualTo(1);
+        assertThat(count429).isEqualTo(numberOfThread - 1);
+    }
+}

--- a/src/test/java/com/asap/server/service/meeting/ConfirmMeetingMethodTest.java
+++ b/src/test/java/com/asap/server/service/meeting/ConfirmMeetingMethodTest.java
@@ -10,19 +10,17 @@ import com.asap.server.domain.enums.PlaceType;
 import com.asap.server.domain.enums.Role;
 import com.asap.server.domain.enums.TimeSlot;
 import com.asap.server.service.MeetingService;
+import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import jakarta.persistence.EntityManager;
-import jakarta.transaction.Transactional;
 import java.util.List;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 @SpringBootTest
-@Transactional
 public class ConfirmMeetingMethodTest {
     @Autowired
     private MeetingService meetingService;

--- a/src/test/java/com/asap/server/service/meeting/ConfirmMeetingMethodTest.java
+++ b/src/test/java/com/asap/server/service/meeting/ConfirmMeetingMethodTest.java
@@ -21,60 +21,60 @@ import java.util.List;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-//@SpringBootTest
-//@Transactional
-//public class ConfirmMeetingMethodTest {
-//    @Autowired
-//    private MeetingService meetingService;
-//    @Autowired
-//    private EntityManager em;
-//
-//    @Test
-//    @DisplayName("회의 확정시 ConfirmedDateTime 은 Update 된다.")
-//    void setConfirmDateTimeTest() {
-//        // given
-//        final Place place = Place.builder()
-//                .placeType(PlaceType.OFFLINE)
-//                .build();
-//        final Meeting meeting = Meeting.builder()
-//                .title("회의 테스트")
-//                .password("0000")
-//                .additionalInfo("")
-//                .duration(Duration.HALF)
-//                .place(place)
-//                .build();
-//        final User user = User.builder()
-//                .meeting(meeting)
-//                .name("강원용")
-//                .role(Role.HOST)
-//                .isFixed(false)
-//                .build();
-//        meeting.setHost(user);
-//
-//        em.persist(meeting);
-//        em.persist(user);
-//        em.flush();
-//        em.clear();
-//
-//        final UserRequestDto userDto = UserRequestDto.builder()
-//                .id(user.getId())
-//                .name(user.getName())
-//                .build();
-//        final MeetingConfirmRequestDto body = MeetingConfirmRequestDto.builder()
-//                .month("09")
-//                .day("07")
-//                .dayOfWeek("월")
-//                .startTime(TimeSlot.SLOT_6_00)
-//                .endTime(TimeSlot.SLOT_6_30)
-//                .users(List.of(userDto))
-//                .build();
-//
-//        // when
-//        meetingService.confirmMeeting(body, meeting.getId(), user.getId());
-//
-//        // then
-//        final Meeting result = em.find(Meeting.class, meeting.getId());
-//        assertThat(result.isConfirmedMeeting()).isTrue();
-//    }
-//
-//}
+@SpringBootTest
+@Transactional
+public class ConfirmMeetingMethodTest {
+    @Autowired
+    private MeetingService meetingService;
+    @Autowired
+    private EntityManager em;
+
+    @Test
+    @DisplayName("회의 확정시 ConfirmedDateTime 은 Update 된다.")
+    void setConfirmDateTimeTest() {
+        // given
+        final Place place = Place.builder()
+                .placeType(PlaceType.OFFLINE)
+                .build();
+        final Meeting meeting = Meeting.builder()
+                .title("회의 테스트")
+                .password("0000")
+                .additionalInfo("")
+                .duration(Duration.HALF)
+                .place(place)
+                .build();
+        final User user = User.builder()
+                .meeting(meeting)
+                .name("강원용")
+                .role(Role.HOST)
+                .isFixed(false)
+                .build();
+        meeting.setHost(user);
+
+        em.persist(meeting);
+        em.persist(user);
+        em.flush();
+        em.clear();
+
+        final UserRequestDto userDto = UserRequestDto.builder()
+                .id(user.getId())
+                .name(user.getName())
+                .build();
+        final MeetingConfirmRequestDto body = MeetingConfirmRequestDto.builder()
+                .month("09")
+                .day("07")
+                .dayOfWeek("월")
+                .startTime(TimeSlot.SLOT_6_00)
+                .endTime(TimeSlot.SLOT_6_30)
+                .users(List.of(userDto))
+                .build();
+
+        // when
+        meetingService.confirmMeeting(body, meeting.getId(), user.getId());
+
+        // then
+        final Meeting result = em.find(Meeting.class, meeting.getId());
+        assertThat(result.isConfirmedMeeting()).isTrue();
+    }
+
+}

--- a/src/test/java/com/asap/server/service/meeting/ConfirmMeetingMethodTest.java
+++ b/src/test/java/com/asap/server/service/meeting/ConfirmMeetingMethodTest.java
@@ -11,6 +11,7 @@ import com.asap.server.domain.enums.Role;
 import com.asap.server.domain.enums.TimeSlot;
 import com.asap.server.service.MeetingService;
 import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,59 +21,60 @@ import java.util.List;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-@SpringBootTest
-public class ConfirmMeetingMethodTest {
-    @Autowired
-    private MeetingService meetingService;
-    @Autowired
-    private EntityManager em;
-
-    @Test
-    @DisplayName("회의 확정시 ConfirmedDateTime 은 Update 된다.")
-    void setConfirmDateTimeTest() {
-        // given
-        final Place place = Place.builder()
-                .placeType(PlaceType.OFFLINE)
-                .build();
-        final Meeting meeting = Meeting.builder()
-                .title("회의 테스트")
-                .password("0000")
-                .additionalInfo("")
-                .duration(Duration.HALF)
-                .place(place)
-                .build();
-        final User user = User.builder()
-                .meeting(meeting)
-                .name("강원용")
-                .role(Role.HOST)
-                .isFixed(false)
-                .build();
-        meeting.setHost(user);
-
-        em.persist(meeting);
-        em.persist(user);
-        em.flush();
-        em.clear();
-
-        final UserRequestDto userDto = UserRequestDto.builder()
-                .id(user.getId())
-                .name(user.getName())
-                .build();
-        final MeetingConfirmRequestDto body = MeetingConfirmRequestDto.builder()
-                .month("09")
-                .day("07")
-                .dayOfWeek("월")
-                .startTime(TimeSlot.SLOT_6_00)
-                .endTime(TimeSlot.SLOT_6_30)
-                .users(List.of(userDto))
-                .build();
-
-        // when
-        meetingService.confirmMeeting(body, meeting.getId(), user.getId());
-
-        // then
-        final Meeting result = em.find(Meeting.class, meeting.getId());
-        assertThat(result.isConfirmedMeeting()).isTrue();
-    }
-
-}
+//@SpringBootTest
+//@Transactional
+//public class ConfirmMeetingMethodTest {
+//    @Autowired
+//    private MeetingService meetingService;
+//    @Autowired
+//    private EntityManager em;
+//
+//    @Test
+//    @DisplayName("회의 확정시 ConfirmedDateTime 은 Update 된다.")
+//    void setConfirmDateTimeTest() {
+//        // given
+//        final Place place = Place.builder()
+//                .placeType(PlaceType.OFFLINE)
+//                .build();
+//        final Meeting meeting = Meeting.builder()
+//                .title("회의 테스트")
+//                .password("0000")
+//                .additionalInfo("")
+//                .duration(Duration.HALF)
+//                .place(place)
+//                .build();
+//        final User user = User.builder()
+//                .meeting(meeting)
+//                .name("강원용")
+//                .role(Role.HOST)
+//                .isFixed(false)
+//                .build();
+//        meeting.setHost(user);
+//
+//        em.persist(meeting);
+//        em.persist(user);
+//        em.flush();
+//        em.clear();
+//
+//        final UserRequestDto userDto = UserRequestDto.builder()
+//                .id(user.getId())
+//                .name(user.getName())
+//                .build();
+//        final MeetingConfirmRequestDto body = MeetingConfirmRequestDto.builder()
+//                .month("09")
+//                .day("07")
+//                .dayOfWeek("월")
+//                .startTime(TimeSlot.SLOT_6_00)
+//                .endTime(TimeSlot.SLOT_6_30)
+//                .users(List.of(userDto))
+//                .build();
+//
+//        // when
+//        meetingService.confirmMeeting(body, meeting.getId(), user.getId());
+//
+//        // then
+//        final Meeting result = em.find(Meeting.class, meeting.getId());
+//        assertThat(result.isConfirmedMeeting()).isTrue();
+//    }
+//
+//}

--- a/src/test/java/com/asap/server/service/meeting/ConfirmMeetingMethodTest.java
+++ b/src/test/java/com/asap/server/service/meeting/ConfirmMeetingMethodTest.java
@@ -1,80 +1,80 @@
-package com.asap.server.service.meeting;
-
-import com.asap.server.controller.dto.request.MeetingConfirmRequestDto;
-import com.asap.server.controller.dto.request.UserRequestDto;
-import com.asap.server.domain.Meeting;
-import com.asap.server.domain.Place;
-import com.asap.server.domain.User;
-import com.asap.server.domain.enums.Duration;
-import com.asap.server.domain.enums.PlaceType;
-import com.asap.server.domain.enums.Role;
-import com.asap.server.domain.enums.TimeSlot;
-import com.asap.server.service.MeetingService;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-
-import jakarta.persistence.EntityManager;
-import jakarta.transaction.Transactional;
-import java.util.List;
-
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-
-@SpringBootTest
-@Transactional
-public class ConfirmMeetingMethodTest {
-    @Autowired
-    private MeetingService meetingService;
-    @Autowired
-    private EntityManager em;
-
-    @Test
-    @DisplayName("회의 확정시 ConfirmedDateTime 은 Update 된다.")
-    void setConfirmDateTimeTest() {
-        // given
-        final Place place = Place.builder()
-                .placeType(PlaceType.OFFLINE)
-                .build();
-        final Meeting meeting = Meeting.builder()
-                .title("회의 테스트")
-                .password("0000")
-                .additionalInfo("")
-                .duration(Duration.HALF)
-                .place(place)
-                .build();
-        final User user = User.builder()
-                .meeting(meeting)
-                .name("강원용")
-                .role(Role.HOST)
-                .isFixed(false)
-                .build();
-        meeting.setHost(user);
-
-        em.persist(meeting);
-        em.persist(user);
-        em.flush();
-        em.clear();
-
-        final UserRequestDto userDto = UserRequestDto.builder()
-                .id(user.getId())
-                .name(user.getName())
-                .build();
-        final MeetingConfirmRequestDto body = MeetingConfirmRequestDto.builder()
-                .month("09")
-                .day("07")
-                .dayOfWeek("월")
-                .startTime(TimeSlot.SLOT_6_00)
-                .endTime(TimeSlot.SLOT_6_30)
-                .users(List.of(userDto))
-                .build();
-
-        // when
-        meetingService.confirmMeeting(body, meeting.getId(), user.getId());
-
-        // then
-        final Meeting result = em.find(Meeting.class, meeting.getId());
-        assertThat(result.isConfirmedMeeting()).isTrue();
-    }
-
-}
+//package com.asap.server.service.meeting;
+//
+//import com.asap.server.controller.dto.request.MeetingConfirmRequestDto;
+//import com.asap.server.controller.dto.request.UserRequestDto;
+//import com.asap.server.domain.Meeting;
+//import com.asap.server.domain.Place;
+//import com.asap.server.domain.User;
+//import com.asap.server.domain.enums.Duration;
+//import com.asap.server.domain.enums.PlaceType;
+//import com.asap.server.domain.enums.Role;
+//import com.asap.server.domain.enums.TimeSlot;
+//import com.asap.server.service.MeetingService;
+//import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.Test;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.boot.test.context.SpringBootTest;
+//
+//import jakarta.persistence.EntityManager;
+//import jakarta.transaction.Transactional;
+//import java.util.List;
+//
+//import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+//
+//@SpringBootTest
+//@Transactional
+//public class ConfirmMeetingMethodTest {
+//    @Autowired
+//    private MeetingService meetingService;
+//    @Autowired
+//    private EntityManager em;
+//
+//    @Test
+//    @DisplayName("회의 확정시 ConfirmedDateTime 은 Update 된다.")
+//    void setConfirmDateTimeTest() {
+//        // given
+//        final Place place = Place.builder()
+//                .placeType(PlaceType.OFFLINE)
+//                .build();
+//        final Meeting meeting = Meeting.builder()
+//                .title("회의 테스트")
+//                .password("0000")
+//                .additionalInfo("")
+//                .duration(Duration.HALF)
+//                .place(place)
+//                .build();
+//        final User user = User.builder()
+//                .meeting(meeting)
+//                .name("강원용")
+//                .role(Role.HOST)
+//                .isFixed(false)
+//                .build();
+//        meeting.setHost(user);
+//
+//        em.persist(meeting);
+//        em.persist(user);
+//        em.flush();
+//        em.clear();
+//
+//        final UserRequestDto userDto = UserRequestDto.builder()
+//                .id(user.getId())
+//                .name(user.getName())
+//                .build();
+//        final MeetingConfirmRequestDto body = MeetingConfirmRequestDto.builder()
+//                .month("09")
+//                .day("07")
+//                .dayOfWeek("월")
+//                .startTime(TimeSlot.SLOT_6_00)
+//                .endTime(TimeSlot.SLOT_6_30)
+//                .users(List.of(userDto))
+//                .build();
+//
+//        // when
+//        meetingService.confirmMeeting(body, meeting.getId(), user.getId());
+//
+//        // then
+//        final Meeting result = em.find(Meeting.class, meeting.getId());
+//        assertThat(result.isConfirmedMeeting()).isTrue();
+//    }
+//
+//}

--- a/src/test/java/com/asap/server/service/meeting/ConfirmMeetingMethodTest.java
+++ b/src/test/java/com/asap/server/service/meeting/ConfirmMeetingMethodTest.java
@@ -1,80 +1,80 @@
-//package com.asap.server.service.meeting;
-//
-//import com.asap.server.controller.dto.request.MeetingConfirmRequestDto;
-//import com.asap.server.controller.dto.request.UserRequestDto;
-//import com.asap.server.domain.Meeting;
-//import com.asap.server.domain.Place;
-//import com.asap.server.domain.User;
-//import com.asap.server.domain.enums.Duration;
-//import com.asap.server.domain.enums.PlaceType;
-//import com.asap.server.domain.enums.Role;
-//import com.asap.server.domain.enums.TimeSlot;
-//import com.asap.server.service.MeetingService;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.springframework.beans.factory.annotation.Autowired;
-//import org.springframework.boot.test.context.SpringBootTest;
-//
-//import jakarta.persistence.EntityManager;
-//import jakarta.transaction.Transactional;
-//import java.util.List;
-//
-//import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-//
-//@SpringBootTest
-//@Transactional
-//public class ConfirmMeetingMethodTest {
-//    @Autowired
-//    private MeetingService meetingService;
-//    @Autowired
-//    private EntityManager em;
-//
-//    @Test
-//    @DisplayName("회의 확정시 ConfirmedDateTime 은 Update 된다.")
-//    void setConfirmDateTimeTest() {
-//        // given
-//        final Place place = Place.builder()
-//                .placeType(PlaceType.OFFLINE)
-//                .build();
-//        final Meeting meeting = Meeting.builder()
-//                .title("회의 테스트")
-//                .password("0000")
-//                .additionalInfo("")
-//                .duration(Duration.HALF)
-//                .place(place)
-//                .build();
-//        final User user = User.builder()
-//                .meeting(meeting)
-//                .name("강원용")
-//                .role(Role.HOST)
-//                .isFixed(false)
-//                .build();
-//        meeting.setHost(user);
-//
-//        em.persist(meeting);
-//        em.persist(user);
-//        em.flush();
-//        em.clear();
-//
-//        final UserRequestDto userDto = UserRequestDto.builder()
-//                .id(user.getId())
-//                .name(user.getName())
-//                .build();
-//        final MeetingConfirmRequestDto body = MeetingConfirmRequestDto.builder()
-//                .month("09")
-//                .day("07")
-//                .dayOfWeek("월")
-//                .startTime(TimeSlot.SLOT_6_00)
-//                .endTime(TimeSlot.SLOT_6_30)
-//                .users(List.of(userDto))
-//                .build();
-//
-//        // when
-//        meetingService.confirmMeeting(body, meeting.getId(), user.getId());
-//
-//        // then
-//        final Meeting result = em.find(Meeting.class, meeting.getId());
-//        assertThat(result.isConfirmedMeeting()).isTrue();
-//    }
-//
-//}
+package com.asap.server.service.meeting;
+
+import com.asap.server.controller.dto.request.MeetingConfirmRequestDto;
+import com.asap.server.controller.dto.request.UserRequestDto;
+import com.asap.server.domain.Meeting;
+import com.asap.server.domain.Place;
+import com.asap.server.domain.User;
+import com.asap.server.domain.enums.Duration;
+import com.asap.server.domain.enums.PlaceType;
+import com.asap.server.domain.enums.Role;
+import com.asap.server.domain.enums.TimeSlot;
+import com.asap.server.service.MeetingService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@SpringBootTest
+@Transactional
+public class ConfirmMeetingMethodTest {
+    @Autowired
+    private MeetingService meetingService;
+    @Autowired
+    private EntityManager em;
+
+    @Test
+    @DisplayName("회의 확정시 ConfirmedDateTime 은 Update 된다.")
+    void setConfirmDateTimeTest() {
+        // given
+        final Place place = Place.builder()
+                .placeType(PlaceType.OFFLINE)
+                .build();
+        final Meeting meeting = Meeting.builder()
+                .title("회의 테스트")
+                .password("0000")
+                .additionalInfo("")
+                .duration(Duration.HALF)
+                .place(place)
+                .build();
+        final User user = User.builder()
+                .meeting(meeting)
+                .name("강원용")
+                .role(Role.HOST)
+                .isFixed(false)
+                .build();
+        meeting.setHost(user);
+
+        em.persist(meeting);
+        em.persist(user);
+        em.flush();
+        em.clear();
+
+        final UserRequestDto userDto = UserRequestDto.builder()
+                .id(user.getId())
+                .name(user.getName())
+                .build();
+        final MeetingConfirmRequestDto body = MeetingConfirmRequestDto.builder()
+                .month("09")
+                .day("07")
+                .dayOfWeek("월")
+                .startTime(TimeSlot.SLOT_6_00)
+                .endTime(TimeSlot.SLOT_6_30)
+                .users(List.of(userDto))
+                .build();
+
+        // when
+        meetingService.confirmMeeting(body, meeting.getId(), user.getId());
+
+        // then
+        final Meeting result = em.find(Meeting.class, meeting.getId());
+        assertThat(result.isConfirmedMeeting()).isTrue();
+    }
+
+}


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #259 

## Key Changes 🔑
1. Wrapping Filter 변경
- 기존의 Wrapping ContentCachingWrapping 객체가 Request Wrapping이 잘 진행되지 않아서 커스텀 Wrapping 객체로 변경하였습니다!
2. Interceptor를 통해 중복된 요청 에러 처리
-  요청이 발생하면 Redis Hash Map에 IP와 RequestBody 값을 Key로 저장한 후 정삭적으로 실행되었을 때 postHandle 을 통해 Rmap에 담겨 있는 값을 삭제, 중간에 예외가 발생했을 때 afterCompletion에서 Rmap 내부의 값을 삭제
- 도중에 같은 요청이 들어온다면, Too Many Request 예외 발생
https://github.com/ASAP-as-soon-as-possible/ASAP_Server/blob/96556e8bc9b88327a5f7af949bf5754af95a8c45/src/main/java/com/asap/server/common/interceptor/DuplicatedInterceptor.java#L23-L27
 - Interceptor를 사용하여 GlobalExceptionHandler가 해당 예외를 처리하고 반환할 수 있게 구현하였습니다.
## To Reviewers 📢
### 테스트 코드
- 처음엔 `@WebMvcTest` 를 통해 컨트롤러 테스트로 진행하려 했지만, 해당 테스트는 redis의 사용도 필요했기 때문에 인수 테스트가 적합하다고 생각해 `@SpringBootTest` 로 작성했습니다.
- `@SpringBootTest` 에는 MockMvc를 `@Autowired` 할 수 없기 때문에 `@AutoConfigureMockMvc` 를 통해서 MockMvc를 `@Autowired` 합니다.
- numberOfThread 수만큼 스레드를 생성해서 회의 생성 API를 호출한 뒤, andReturn()을 통해 수행 결과를 list에 추가합니다.
    - RMap key를 만들 때, x-real-ip 주소 값을 사용하기 때문에 테스트 시 x-real-ip 헤더를 추가합니다.
    - 람다 내부에서는 final 변수만 사용할 수 있기 때문에 외부에서 해당 결과를 테스트하기 위해서 MvcResult를 list에 추가했습니다.
    - numberOfThread 수만큼 스레드를 생성하기 때문에 MvcResult를 add하는 과정에서 여러 스레드가 동시에 add한 결과 numberOfThread-1 만큼 add가 되는 상황이 발생할 수 있습니다. 그렇기 때문에 synchronized를 통해서 results에 lock을 걸며 순차적으로 perform 결과를 add합니다.
- 모든 스레드의 작업이 끝날 때까지 latch.await()를 통해 기다립니다.
- 이후 results를 순회하며 200이 나온 횟수과 429가 나온 횟수를 구해서 테스트 결과를 검증합니다.
- 이 때, 결과는 200이 나온 횟수는 단 1번이 나와야 하고, 429가 나온 횟수는 numberOfThread-1 만큼 나와야 합니다.
