### PR TITLE
#274 [hotfix] 회의 참여 인원 조회 쿼리 meeting id 조건 추가

### DIFF
--- a/src/main/java/com/asap/server/repository/user/UserRepositoryCustom.java
+++ b/src/main/java/com/asap/server/repository/user/UserRepositoryCustom.java
@@ -10,5 +10,5 @@ import java.util.List;
 public interface UserRepositoryCustom {
     void updateUserIsFixedByMeeting(final Meeting meeting, final List<Long> users);
 
-    List<UserVo> findByAvailableDateAndTimeSlots(LocalDate availableDate, List<TimeSlot> timeSlots);
+    List<UserVo> findByAvailableDateAndTimeSlots(Long meetingId, LocalDate availableDate, List<TimeSlot> timeSlots);
 }

--- a/src/main/java/com/asap/server/repository/user/UserRepositoryImpl.java
+++ b/src/main/java/com/asap/server/repository/user/UserRepositoryImpl.java
@@ -30,7 +30,11 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
     }
 
     @Override
-    public List<UserVo> findByAvailableDateAndTimeSlots(LocalDate date, List<TimeSlot> timeSlots) {
+    public List<UserVo> findByAvailableDateAndTimeSlots(
+            Long meetingId,
+            LocalDate date,
+            List<TimeSlot> timeSlots
+    ) {
         return queryFactory.select(
                         new QUserVo(
                                 user.id,
@@ -40,7 +44,11 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
                 .innerJoin(timeBlock).on(timeBlockUser.timeBlock.id.eq(timeBlock.id))
                 .innerJoin(user).on(timeBlockUser.user.id.eq(user.id))
                 .innerJoin(availableDate).on(timeBlock.availableDate.id.eq(availableDate.id))
-                .where(availableDate.date.eq(date).and(timeBlock.timeSlot.in(timeSlots)))
+                .where(
+                        availableDate.date.eq(date)
+                                .and(availableDate.meeting.id.eq(meetingId))
+                                .and(timeBlock.timeSlot.in(timeSlots))
+                )
                 .groupBy(user.id)
                 .fetch();
     }

--- a/src/main/java/com/asap/server/service/MeetingService.java
+++ b/src/main/java/com/asap/server/service/MeetingService.java
@@ -199,7 +199,7 @@ public class MeetingService {
         List<TimeBlockDto> timeBlocks = timeBlockRepository.findAllTimeBlockByMeeting(meetingId);
 
         List<BestMeetingTimeVo> bestMeetingTimes = meetingTimeRecommendService.getBestMeetingTime(timeBlocks, meeting.getDuration(), userCount);
-        List<BestMeetingTimeWithUsersVo> bestMeetingTimeWithUsers = userService.getBestMeetingInUsers(bestMeetingTimes);
+        List<BestMeetingTimeWithUsersVo> bestMeetingTimeWithUsers = userService.getBestMeetingInUsers(meetingId, bestMeetingTimes);
         return BestMeetingTimeResponseDto.of(userCount, bestMeetingTimeWithUsers);
     }
 

--- a/src/main/java/com/asap/server/service/UserService.java
+++ b/src/main/java/com/asap/server/service/UserService.java
@@ -183,16 +183,26 @@ public class UserService {
         return responseDto;
     }
 
-    public List<BestMeetingTimeWithUsersVo> getBestMeetingInUsers(List<BestMeetingTimeVo> bestMeetingTimes) {
+    public List<BestMeetingTimeWithUsersVo> getBestMeetingInUsers(
+            final Long meetingId,
+            final List<BestMeetingTimeVo> bestMeetingTimes
+    ) {
         return bestMeetingTimes.stream()
-                .map(this::getBestMeetingTimeInUsers)
+                .map(bestMeetingTime -> getBestMeetingTimeInUsers(meetingId, bestMeetingTime))
                 .collect(Collectors.toList());
     }
 
-    private BestMeetingTimeWithUsersVo getBestMeetingTimeInUsers(final BestMeetingTimeVo bestMeetingTime) {
-        if (bestMeetingTime == null) return null;
-        List<TimeSlot> timeSlots = TimeSlot.getTimeSlots(bestMeetingTime.startTime().ordinal(), bestMeetingTime.endTime().ordinal() - 1);
-        List<UserVo> users = userRepository.findByAvailableDateAndTimeSlots(bestMeetingTime.date(), timeSlots);
+    private BestMeetingTimeWithUsersVo getBestMeetingTimeInUsers(
+            final Long meetingId,
+            final BestMeetingTimeVo bestMeetingTime
+    ) {
+        if (bestMeetingTime == null) {
+            return null;
+        }
+        List<TimeSlot> timeSlots = TimeSlot.getTimeSlots(bestMeetingTime.startTime().ordinal(),
+                bestMeetingTime.endTime().ordinal() - 1);
+        List<UserVo> users = userRepository.findByAvailableDateAndTimeSlots(meetingId, bestMeetingTime.date(),
+                timeSlots);
         return BestMeetingTimeWithUsersVo.of(bestMeetingTime, users);
     }
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #274 

## Key Changes 🔑
1. 내용
다른 회의에서 동일한 date, 동일한 time_slot에 해당하는 유저의 정보까지 불러오는 이슈 발견

## To Reviewers 📢
- query 내부에 meeting id를 추가해 특정 회의의 정보만 불러오도록 수정
