### PR TITLE
#277 [feat] CD 방식 도커로 수정

### DIFF
--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -1,96 +1,65 @@
-# 워크플로우의 이름 지정
 name: ASAP-Server CD
 
-# 해당 workflow가 언제 실행될 것인지에 대한 트리거를 지정
 on:
   push:
-    branches: [ "main" ] # main branch로 push 될 때 실행됩니다.
-
-env:
-  S3_BUCKET_NAME: asap-prod
+    branches: [ "main" ]
 
 jobs:
   build:
     name: Code deployment
 
-    # 실행 환경
     runs-on: ubuntu-latest
 
     steps:
+      - name: checkout
+        uses: actions/checkout@v3
 
-    # 1) 워크플로우 실행 전 기본적으로 체크아웃 필요
-    - name: checkout
-      uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
 
-    # 2) JDK 11버전 설치, 다른 JDK 버전을 사용하다면 수정
-    - name: Set up JDK 17
-      uses: actions/setup-java@v3
-      with:
-        java-version: '17'
-        distribution: 'temurin'
+      - name: make application.yml 파일 생성
+        run: |
+          ## create application.yml
+          cd ./src/main/resources
+          
+          # application.yml 파일 생성
+          touch ./application.yml
+          
+          # GitHub-Actions 에서 설정한 값을 application.yml 파일에 쓰기
+          echo "${{ secrets.DOCKER_YAML }}" >> ./application.yml
+          
+          # application.yml 파일 확인
+          cat ./application.yml
+        shell: bash
 
-    # 3) 환경변수 파일 생성
-    - name: make application.properties 파일 생성
-      run: |
-        ## create application.yml
-        cd ./src/main/resources
+      - name: Build with Gradle
+        run: |
+          chmod +x gradlew
+          ./gradlew build -x test
 
-        # application.yml 파일 생성
-        touch ./application.yml
+      - name: docker build 가능하도록 환경 설정
+        uses: docker/setup-buildx-action@v2.9.1
 
-        # GitHub-Actions 에서 설정한 값을 application.yml 파일에 쓰기
-        echo "${{ secrets.ASAP_APPLICATION }}" >> ./application.yml
-        
-        # application.yml 파일 확인
-        cat ./application.yml
-      shell: bash
+      - name: docker hub에로그인
+        uses: docker/login-action@v2.2.0
+        with:
+          username: ${{ secrets.DOCKERHUB_LOGIN_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_LOGIN_ACCESSTOKEN }}
 
-    # 이 워크플로우는 gradle build
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
+      - name: docker image 빌드 및 푸시
+        run: |
+          docker build --platform linux/amd64 -t ${{ secrets.DOCKERHUB_LOGIN_USERNAME }}/${{ secrets.DOCKERHUB_IMAGE_NAME }} .
+          docker push ${{ secrets.DOCKERHUB_LOGIN_USERNAME }}/${{ secrets.DOCKERHUB_IMAGE_NAME }}
 
-    - name: Build with Gradle # 실제 application build(-x 옵션을 통해 test는 제외)
-      run: ./gradlew build -x test
-
-    # 디렉토리 생성
-    - name: Make Directory
-      run: mkdir -p deploy
-
-    # Jar 파일 복사
-    - name: Copy Jar
-      run: cp ./build/libs/*.jar ./deploy
-
-    # appspec.yml 파일 복사
-    - name: Copy appspec.yml
-      run: cp appspec.yml ./deploy
-
-    # script files 복사
-    - name: Copy script
-      run: cp ./scripts/*.sh ./deploy
-
-    - name: Make zip file
-      run: zip -r ./asap_server.zip ./deploy
-      shell: bash
-
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
-        aws-region: ap-northeast-2
-
-    - name: Upload to S3
-      run: aws s3 cp --region ap-northeast-2 ./asap_server.zip s3://$S3_BUCKET_NAME/
-
-    # Deploy
-    - name: Deploy
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
-      run:
-        aws deploy create-deployment 
-        --application-name asap-prod-code-deploy
-        --deployment-group-name asap-prod-code-deploy-group
-        --file-exists-behavior OVERWRITE 
-        --s3-location bucket=$S3_BUCKET_NAME,bundleType=zip,key=asap_server.zip
-        --region ap-northeast-2
+      - name: 도커 컨테이너 실행
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.RELEASE_SERVER_IP }}
+          username: ${{ secrets.RELEASE_SERVER_USER }}
+          key: ${{ secrets.RELEASE_SERVER_KEY }}
+          script: |
+            cd ~
+            sudo ./deploy.sh

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -59,8 +59,10 @@ jobs:
 
       - name: docker image 빌드 및 푸시
         run: |
-          docker build --platform linux/amd64 -t ${{ secrets.DOCKERHUB_LOGIN_USERNAME }}/${{ secrets.DOCKERHUB_IMAGE_NAME }}:${{ steps.server_version.outputs.version }} .
+          docker build --platform linux/amd64 -t ${{ secrets.DOCKERHUB_LOGIN_USERNAME }}/${{ secrets.DOCKERHUB_IMAGE_NAME }} .
+          docker tag ${{ secrets.DOCKERHUB_LOGIN_USERNAME }}/${{ secrets.DOCKERHUB_IMAGE_NAME }} ${{ secrets.DOCKERHUB_LOGIN_USERNAME }}/${{ secrets.DOCKERHUB_IMAGE_NAME }}:${{ steps.server_version.outputs.version }}
           docker push ${{ secrets.DOCKERHUB_LOGIN_USERNAME }}/${{ secrets.DOCKERHUB_IMAGE_NAME }}:${{ steps.server_version.outputs.version }}
+          docker push ${{ secrets.DOCKERHUB_LOGIN_USERNAME }}/${{ secrets.DOCKERHUB_IMAGE_NAME }}
 
       - name: 도커 컨테이너 실행
         uses: appleboy/ssh-action@master

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -49,10 +49,18 @@ jobs:
           username: ${{ secrets.DOCKERHUB_LOGIN_USERNAME }}
           password: ${{ secrets.DOCKERHUB_LOGIN_ACCESSTOKEN }}
 
+      - name: JAR file 로 부터 서버 버전 추출
+        id: server_version
+        run: |
+          jar_file=$(ls build/libs/server-*.jar | head -n 1)
+          version=$(echo $jar_file | grep -oP 'server-\K[^\-]+(?=\.jar)')
+          echo "Version: $version"
+          echo "::set-output name=version::$version"
+
       - name: docker image 빌드 및 푸시
         run: |
-          docker build --platform linux/amd64 -t ${{ secrets.DOCKERHUB_LOGIN_USERNAME }}/${{ secrets.DOCKERHUB_IMAGE_NAME }} .
-          docker push ${{ secrets.DOCKERHUB_LOGIN_USERNAME }}/${{ secrets.DOCKERHUB_IMAGE_NAME }}
+          docker build --platform linux/amd64 -t ${{ secrets.DOCKERHUB_LOGIN_USERNAME }}/${{ secrets.DOCKERHUB_IMAGE_NAME }}:${{ steps.server_version.outputs.version }} .
+          docker push ${{ secrets.DOCKERHUB_LOGIN_USERNAME }}/${{ secrets.DOCKERHUB_IMAGE_NAME }}:${{ steps.server_version.outputs.version }}
 
       - name: 도커 컨테이너 실행
         uses: appleboy/ssh-action@master

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM amd64/amazoncorretto:17-alpine
 
-COPY ./build/libs/server-0.0.1-SNAPSHOT.jar /asap-server.jar
+COPY ./build/libs/*.jar /asap-server.jar
 
 CMD ["java", "-Duser.timezone=Asia/Seoul", "-jar", "asap-server.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM amd64/amazoncorretto:17-alpine
+
+COPY ./build/libs/server-0.0.1-SNAPSHOT.jar /asap-server.jar
+
+CMD ["java", "-Duser.timezone=Asia/Seoul", "-jar", "asap-server.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -5,10 +5,18 @@ plugins {
 }
 
 group = 'com.asap'
-version = '0.0.1-SNAPSHOT'
+version = '1.1.1'
 
 java {
     sourceCompatibility = '17'
+}
+
+jar {
+    enabled = false;
+}
+
+bootJar {
+    enabled = true;
 }
 
 configurations {

--- a/src/main/resources/file-error-appender.xml
+++ b/src/main/resources/file-error-appender.xml
@@ -1,6 +1,6 @@
 <included>
     <appender name="FILE-ERROR" class="ch.qos.logback.core.FileAppender">
-        <file>/home/ubuntu/app/logs/error/error-${BY_DATE}.log</file>
+        <file>/logs/error/error-${BY_DATE}.log</file>
         <append>true</append>
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>ERROR</level>

--- a/src/main/resources/file-info-appender.xml
+++ b/src/main/resources/file-info-appender.xml
@@ -1,6 +1,6 @@
 <included>
     <appender name="FILE-INFO" class="ch.qos.logback.core.FileAppender">
-        <file>/home/ubuntu/app/logs/info/info-${BY_DATE}.log</file>
+        <file>/logs/info/info-${BY_DATE}.log</file>
         <append>true</append>
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>INFO</level>


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #277 

## Key Changes 🔑
1. 내용
   - Docker를 사용한 배포 방식이 메모리가 더 절약되는 것을 보고
   - CD 방식을 Code Deploy에서 Docker로 수정했습니다.
   - 아래와 같은 작업을 진행했습니다.

## To Reviewers 📢
### EC2
<details>
<summary>deploy.sh 정의</summary>
<div markdown="1">

```Shell
#!/bin/bash

docker_ps_output=$(sudo docker ps | grep $server_name)

echo "> ${docker_ps_output} docker_ps_output"

running_container_name=$(echo "$docker_ps_output" | awk '{print $NF}')

echo "> ${running_container_name} container_name"

blue_port=$(echo "$running_container_name" | awk -F'-' '{print $NF}')

echo "> ${blue_port} 블루포트"

if [ "$blue_port" = "8080" ]; then
  green_port=8081
elif [ "$blue_port" = "8081" ]; then
  green_port=8080
else
  echo "> 실행 중인 port가 없습니다."
  echo "> 8080을 할당합니다."
  green_port=8080
fi

echo "> 도커 이미지 pull 받기"
docker pull ${docker_user_name}/${server_name}

echo "> ${green_port} 포트로 서버 실행"
docker run -d --name ${server_name}-${green_port} -v `pwd`/logs:/logs --network asap -p ${green_port}:8080 -e TZ=Asia/Seoul ${docker_user_name}/${server_name}

echo "> 10초 후 Health check 시작"
echo "> curl -s http://localhost:$green_port/actuator/health "
sleep 10

for retry_count in {1..10}
do
  response=$(curl -s http://localhost:$green_port/actuator/health)
  up_count=$(echo $response | grep 'UP' | wc -l)

  if [ $up_count -ge 1 ]
  then # $up_count >= 1 ("UP" 문자열이 있는지 검증)
      echo "> Health check 성공"
      break
  else
      echo "> Health check의 응답을 알 수 없거나 혹은 status가 UP이 아닙니다."
      echo "> Health check: ${response}"
  fi

  if [ $retry_count -eq 10 ]
  then
    echo "> Health check 실패. "
    echo "> Nginx에 연결하지 않고 배포를 종료합니다."
    exit 1
  fi

  echo "> Health check 연결 실패. 재시도..."
  sleep 10
done

# nginx switching
echo "> nginx 포트 스위칭"
echo "set \$service_url http://127.0.0.1:${green_port};" | sudo tee /etc/nginx/conf.d/service-url.inc
sudo nginx -s reload

# blue_port 서버 있다면 중단
if [ -n "$blue_port" ]; then
    echo "> 기존 ${blue_port}포트 서버 중단"
    echo "> docker rm -f ${server_name}-${blue_port}"
    sudo docker rm -f ${server_name}-${blue_port}
fi
```
</div>
</details>

- 도커 내부에 쌓이는 로깅 파일들 `bind mount` 를 이용해 host에 저장하도록 설정
    - volume을 사용해서 로깅 파일들을 저장할 수 있었지만, docker에 접속해서 로깅 파일을 알아보는 번거로움 없이 ec2 환경에서 바로 볼 수 있도록 `bind mount` 를 사용했습니다.

- 필요 없는 프로그램 삭제
    - Redis, Code Deploy를 위한 설치했던 프로그램 등을 전부 삭제했습니다.
    - 삭제 프로그램 : Redis, Code Deploy, Ruby, wget

### Github 
- Github Actions workflow 수정
    - 도커를 사용해서 cd가 되도록 workflow를 수정했습니다.

    - 배포 환경 버전에 따라서 이미지를 버저닝해서 푸시하는 기능을 추가했습니다. 자세한 내용은 [커밋1](f152f21ad87803f0e588e7cafbfc2204201b2fa4), [커밋2](https://github.com/ASAP-as-soon-as-possible/ASAP_Server/pull/279/commits/5659b1d50623f5d9240c78a0b8a0cba35e683a4a) 참고해주세요.

### Code

- Dockerfile , alpine 버전 사용
    - Dockerfile을 보시면 latest 버전을 사용하지 않고 alpine 버전을 사용하는 것을 볼 수 있습니다. alpine 버전은 리눅스를 위한 버전으로 더 이미지 용량 적게 들고, 이로 인해 저희 이미지 용량까지 줄어든 것을 확인할 수 있었습니다. 하지만 alpine 버전에서는 **부분적으로 저희가 사용하는 명령어가 없거나 다른 명령어를 사용해야 하기 때문에 이 점 주의**해야 합니다..! 하지만 **용량이 줄어든다는 점이 마음에 들어 alpine 버전을 채택**했습니다.
    ex) 도커 컨테이너 내부로 들어갈 때 명령어
        - sudo docker exec -it "containerId" /bin/bash [일반적으로 사용하는 방식]
        - sudo docker exec -it "containerId" /bin/sh [alpine 방식]

## 마지막으로 하고 싶은 말
![image](https://github.com/ASAP-as-soon-as-possible/ASAP_Server/assets/82709044/475b0fb7-e0d0-49ab-81f6-39d29a0d4e6b)

이런 식으로 이미지를 버저닝 할 수 있습니다.
따라서 규칙 하나를 추가하려 하는데요!!
바로 develop → main으로 머지하기 위해 PR을 올릴 때, build gradle 버전을 변경한 뒤 PR을 올리고 머지를 하는 규칙입니다.
이 부분만 감안한다면 자동으로 버저닝을 될 것이라

추후에 이전 버전으로 배포 환경을 롤백 해야 할 때, 변경하는 것이 더욱 쉬워질 것입니다!!
