### PR TITLE
#293 [feat] BestMeetingTimeStrategy 구현체 로직 개발

### DIFF
--- a/src/main/java/com/asap/server/service/meeting/recommend/MeetingTimeRecommendService.java
+++ b/src/main/java/com/asap/server/service/meeting/recommend/MeetingTimeRecommendService.java
@@ -34,7 +34,7 @@ public class MeetingTimeRecommendService {
 
             List<BestMeetingTimeVo> candidateMeetingTimes = new ArrayList<>(
                     continuousMeetingTimeStrategy.find(timeBlocksFilteredUserCount, timeCase.duration()));
-            candidateMeetingTimes = bestMeetingTimeStrategy.find(candidateMeetingTimes);
+            candidateMeetingTimes = bestMeetingTimeStrategy.find(candidateMeetingTimes, timeCase.duration());
             bestMeetingTimes.addAll(candidateMeetingTimes);
 
             if (bestMeetingTimes.size() < BEST_MEETING_TIME_SIZE) {

--- a/src/main/java/com/asap/server/service/meeting/recommend/strategy/BestMeetingTimeStrategy.java
+++ b/src/main/java/com/asap/server/service/meeting/recommend/strategy/BestMeetingTimeStrategy.java
@@ -1,8 +1,9 @@
 package com.asap.server.service.meeting.recommend.strategy;
 
+import com.asap.server.persistence.domain.enums.Duration;
 import com.asap.server.service.vo.BestMeetingTimeVo;
 import java.util.List;
 
 public interface BestMeetingTimeStrategy {
-    List<BestMeetingTimeVo> find(List<BestMeetingTimeVo> candidateMeetingTimes);
+    List<BestMeetingTimeVo> find(List<BestMeetingTimeVo> candidateMeetingTimes, Duration duration);
 }

--- a/src/main/java/com/asap/server/service/meeting/recommend/strategy/impl/BestMeetingTimeStrategyImpl.java
+++ b/src/main/java/com/asap/server/service/meeting/recommend/strategy/impl/BestMeetingTimeStrategyImpl.java
@@ -16,21 +16,21 @@ public class BestMeetingTimeStrategyImpl implements BestMeetingTimeStrategy {
     public List<BestMeetingTimeVo> find(List<BestMeetingTimeVo> candidateMeetingTimes, Duration duration) {
         List<BestMeetingTimeVo> bestMeetingTimes = new ArrayList<>();
         for (BestMeetingTimeVo candidate : candidateMeetingTimes) {
-            bestMeetingTimes.add(createFirstTimeSlot(candidate, duration));
+            bestMeetingTimes.add(createFirstMeetingTime(candidate, duration));
 
             if (isTimeBlockSufficientlyLong(candidate, duration)) {
-                bestMeetingTimes.add(createSecondTimeSlot(candidate, duration));
+                bestMeetingTimes.add(createSecondMeetingTime(candidate, duration));
             }
         }
         return bestMeetingTimes;
     }
 
-    private BestMeetingTimeVo createFirstTimeSlot(BestMeetingTimeVo candidate, Duration duration) {
+    private BestMeetingTimeVo createFirstMeetingTime(BestMeetingTimeVo candidate, Duration duration) {
         TimeSlot endTimeSlot = TimeSlot.getTimeSlot(candidate.startTime().getIndex() + duration.getNeedBlock());
         return new BestMeetingTimeVo(candidate.date(), candidate.startTime(), endTimeSlot, candidate.weight());
     }
 
-    private BestMeetingTimeVo createSecondTimeSlot(BestMeetingTimeVo candidate, Duration duration) {
+    private BestMeetingTimeVo createSecondMeetingTime(BestMeetingTimeVo candidate, Duration duration) {
         TimeSlot startTimeSlot = TimeSlot.getTimeSlot(candidate.endTime().getIndex() - duration.getNeedBlock());
         return new BestMeetingTimeVo(candidate.date(), startTimeSlot, candidate.endTime(), candidate.weight());
     }

--- a/src/main/java/com/asap/server/service/meeting/recommend/strategy/impl/BestMeetingTimeStrategyImpl.java
+++ b/src/main/java/com/asap/server/service/meeting/recommend/strategy/impl/BestMeetingTimeStrategyImpl.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class BestMeetingTimeStrategyImpl implements BestMeetingTimeStrategy {
     @Override
-    public List<BestMeetingTimeVo> find(List<BestMeetingTimeVo> candidateMeetingTimes) {
         return null;
+    public List<BestMeetingTimeVo> find(List<BestMeetingTimeVo> candidateMeetingTimes, Duration duration) {
     }
 }

--- a/src/main/java/com/asap/server/service/meeting/recommend/strategy/impl/BestMeetingTimeStrategyImpl.java
+++ b/src/main/java/com/asap/server/service/meeting/recommend/strategy/impl/BestMeetingTimeStrategyImpl.java
@@ -1,14 +1,42 @@
 package com.asap.server.service.meeting.recommend.strategy.impl;
 
+import com.asap.server.persistence.domain.enums.Duration;
+import com.asap.server.persistence.domain.enums.TimeSlot;
 import com.asap.server.service.meeting.recommend.strategy.BestMeetingTimeStrategy;
 import com.asap.server.service.vo.BestMeetingTimeVo;
+import java.util.ArrayList;
 import java.util.List;
 import org.springframework.stereotype.Component;
 
 @Component
 public class BestMeetingTimeStrategyImpl implements BestMeetingTimeStrategy {
+    private static final int EXTRA_BLOCKS = 4;
+
     @Override
-        return null;
     public List<BestMeetingTimeVo> find(List<BestMeetingTimeVo> candidateMeetingTimes, Duration duration) {
+        List<BestMeetingTimeVo> bestMeetingTimes = new ArrayList<>();
+        for (BestMeetingTimeVo candidate : candidateMeetingTimes) {
+            bestMeetingTimes.add(createFirstTimeSlot(candidate, duration));
+
+            if (isTimeBlockSufficientlyLong(candidate, duration)) {
+                bestMeetingTimes.add(createSecondTimeSlot(candidate, duration));
+            }
+        }
+        return bestMeetingTimes;
+    }
+
+    private BestMeetingTimeVo createFirstTimeSlot(BestMeetingTimeVo candidate, Duration duration) {
+        TimeSlot endTimeSlot = TimeSlot.getTimeSlot(candidate.startTime().getIndex() + duration.getNeedBlock());
+        return new BestMeetingTimeVo(candidate.date(), candidate.startTime(), endTimeSlot, candidate.weight());
+    }
+
+    private BestMeetingTimeVo createSecondTimeSlot(BestMeetingTimeVo candidate, Duration duration) {
+        TimeSlot startTimeSlot = TimeSlot.getTimeSlot(candidate.endTime().getIndex() - duration.getNeedBlock());
+        return new BestMeetingTimeVo(candidate.date(), startTimeSlot, candidate.endTime(), candidate.weight());
+    }
+
+    private boolean isTimeBlockSufficientlyLong(BestMeetingTimeVo candidate, Duration duration) {
+        int timeBlockLength = candidate.endTime().getIndex() - candidate.startTime().getIndex();
+        return timeBlockLength >= duration.getNeedBlock() * 2 + EXTRA_BLOCKS;
     }
 }

--- a/src/test/java/com/asap/server/service/meeting/recommend/strategy/impl/BestMeetingTimeStrategyImplTest.java
+++ b/src/test/java/com/asap/server/service/meeting/recommend/strategy/impl/BestMeetingTimeStrategyImplTest.java
@@ -1,0 +1,288 @@
+package com.asap.server.service.meeting.recommend.strategy.impl;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.asap.server.persistence.domain.enums.Duration;
+import com.asap.server.persistence.domain.enums.TimeSlot;
+import com.asap.server.service.meeting.recommend.strategy.BestMeetingTimeStrategy;
+import com.asap.server.service.vo.BestMeetingTimeVo;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class BestMeetingTimeStrategyImplTest {
+    private final BestMeetingTimeStrategy continuousMeetingTimeStrategy = new BestMeetingTimeStrategyImpl();
+
+    @DisplayName("회의 진행 시간이 30분인 경우, 3시간 이상인 블록은 긴 블록으로 처리한다.")
+    @Nested
+    class DurationHalfTest {
+        Duration duration = Duration.HALF;
+
+        @DisplayName("14:00 - 16:00 returns 14:00 - 14:30")
+        @Test
+        void test() {
+            // given
+            LocalDate availableDate = LocalDate.of(2023, 7, 10);
+            BestMeetingTimeVo bestMeetingTimeVo =
+                    new BestMeetingTimeVo(availableDate, TimeSlot.SLOT_14_00, TimeSlot.SLOT_16_00, 0);
+            List<BestMeetingTimeVo> candidateMeetingTimes = List.of(bestMeetingTimeVo);
+
+            BestMeetingTimeVo e1 = new BestMeetingTimeVo(availableDate, TimeSlot.SLOT_14_00, TimeSlot.SLOT_14_30, 0);
+            List<BestMeetingTimeVo> expected = List.of(e1);
+
+            // when
+            List<BestMeetingTimeVo> response = continuousMeetingTimeStrategy.find(candidateMeetingTimes, duration);
+
+            // then
+            assertThat(response).isEqualTo(expected);
+        }
+
+        @DisplayName("14:00 - 17:00 returns 14:00 - 14:30, 16:30 - 17:00")
+        @Test
+        void test2() {
+            // given
+            LocalDate availableDate = LocalDate.of(2023, 7, 10);
+            BestMeetingTimeVo bestMeetingTimeVo =
+                    new BestMeetingTimeVo(availableDate, TimeSlot.SLOT_14_00, TimeSlot.SLOT_17_00, 0);
+            List<BestMeetingTimeVo> candidateMeetingTimes = List.of(bestMeetingTimeVo);
+
+            BestMeetingTimeVo e1 = new BestMeetingTimeVo(availableDate, TimeSlot.SLOT_14_00, TimeSlot.SLOT_14_30, 0);
+            BestMeetingTimeVo e2 = new BestMeetingTimeVo(availableDate, TimeSlot.SLOT_16_30, TimeSlot.SLOT_17_00, 0);
+            List<BestMeetingTimeVo> expected = List.of(e1, e2);
+
+            // when
+            List<BestMeetingTimeVo> response = continuousMeetingTimeStrategy.find(candidateMeetingTimes, duration);
+
+            // then
+            assertThat(response).isEqualTo(expected);
+        }
+    }
+
+    @DisplayName("회의 진행 시간이 1시간인 경우, 4시간 이상인 블록은 긴 블록으로 처리한다.")
+    @Nested
+    class DurationHourTest {
+        Duration duration = Duration.HOUR;
+
+        @DisplayName("14:00 - 16:00 returns 14:00 - 15:00")
+        @Test
+        void test() {
+            // given
+            LocalDate availableDate = LocalDate.of(2023, 7, 10);
+            BestMeetingTimeVo bestMeetingTimeVo =
+                    new BestMeetingTimeVo(availableDate, TimeSlot.SLOT_14_00, TimeSlot.SLOT_16_00, 0);
+            List<BestMeetingTimeVo> candidateMeetingTimes = List.of(bestMeetingTimeVo);
+
+            BestMeetingTimeVo e1 = new BestMeetingTimeVo(availableDate, TimeSlot.SLOT_14_00, TimeSlot.SLOT_15_00, 0);
+            List<BestMeetingTimeVo> expected = List.of(e1);
+
+            // when
+            List<BestMeetingTimeVo> response = continuousMeetingTimeStrategy.find(candidateMeetingTimes, duration);
+
+            // then
+            assertThat(response).isEqualTo(expected);
+        }
+
+        @DisplayName("14:00 - 18:00 returns 14:00 - 15:00, 17:00 - 18:00")
+        @Test
+        void test2() {
+            // given
+            LocalDate availableDate = LocalDate.of(2023, 7, 10);
+            BestMeetingTimeVo bestMeetingTimeVo =
+                    new BestMeetingTimeVo(availableDate, TimeSlot.SLOT_14_00, TimeSlot.SLOT_18_00, 0);
+            List<BestMeetingTimeVo> candidateMeetingTimes = List.of(bestMeetingTimeVo);
+
+            BestMeetingTimeVo e1 = new BestMeetingTimeVo(availableDate, TimeSlot.SLOT_14_00, TimeSlot.SLOT_15_00, 0);
+            BestMeetingTimeVo e2 = new BestMeetingTimeVo(availableDate, TimeSlot.SLOT_17_00, TimeSlot.SLOT_18_00, 0);
+            List<BestMeetingTimeVo> expected = List.of(e1, e2);
+
+            // when
+            List<BestMeetingTimeVo> response = continuousMeetingTimeStrategy.find(candidateMeetingTimes, duration);
+
+            // then
+            assertThat(response).isEqualTo(expected);
+        }
+    }
+
+    @DisplayName("회의 진행 시간이 1시간 30분인 경우, 5시간 이상인 블록은 긴 블록으로 처리한다.")
+    @Nested
+    class DurationHourHalfTest {
+        Duration duration = Duration.HOUR_HALF;
+
+        @DisplayName("14:00 - 16:00 returns 14:00 - 15:30")
+        @Test
+        void test() {
+            // given
+            LocalDate availableDate = LocalDate.of(2023, 7, 10);
+            BestMeetingTimeVo bestMeetingTimeVo =
+                    new BestMeetingTimeVo(availableDate, TimeSlot.SLOT_14_00, TimeSlot.SLOT_16_30, 0);
+            List<BestMeetingTimeVo> candidateMeetingTimes = List.of(bestMeetingTimeVo);
+
+            BestMeetingTimeVo e1 = new BestMeetingTimeVo(availableDate, TimeSlot.SLOT_14_00, TimeSlot.SLOT_15_30, 0);
+            List<BestMeetingTimeVo> expected = List.of(e1);
+
+            // when
+            List<BestMeetingTimeVo> response = continuousMeetingTimeStrategy.find(candidateMeetingTimes, duration);
+
+            // then
+            assertThat(response).isEqualTo(expected);
+        }
+
+        @DisplayName("14:00 - 19:00 returns 14:00 - 15:30, 17:30 - 19:00")
+        @Test
+        void test2() {
+            // given
+            LocalDate availableDate = LocalDate.of(2023, 7, 10);
+            BestMeetingTimeVo bestMeetingTimeVo =
+                    new BestMeetingTimeVo(availableDate, TimeSlot.SLOT_14_00, TimeSlot.SLOT_19_00, 0);
+            List<BestMeetingTimeVo> candidateMeetingTimes = List.of(bestMeetingTimeVo);
+
+            BestMeetingTimeVo e1 = new BestMeetingTimeVo(availableDate, TimeSlot.SLOT_14_00, TimeSlot.SLOT_15_30, 0);
+            BestMeetingTimeVo e2 = new BestMeetingTimeVo(availableDate, TimeSlot.SLOT_17_30, TimeSlot.SLOT_19_00, 0);
+            List<BestMeetingTimeVo> expected = List.of(e1, e2);
+
+            // when
+            List<BestMeetingTimeVo> response = continuousMeetingTimeStrategy.find(candidateMeetingTimes, duration);
+
+            // then
+            assertThat(response).isEqualTo(expected);
+        }
+    }
+
+    @DisplayName("회의 진행 시간이 2시간인 경우, 6시간 이상인 블록은 긴 블록으로 처리한다.")
+    @Nested
+    class DurationTwoHourTest {
+        Duration duration = Duration.TWO_HOUR;
+
+        @DisplayName("14:00 - 16:00 returns 14:00 - 16:00")
+        @Test
+        void test() {
+            // given
+            LocalDate availableDate = LocalDate.of(2023, 7, 10);
+            BestMeetingTimeVo bestMeetingTimeVo =
+                    new BestMeetingTimeVo(availableDate, TimeSlot.SLOT_14_00, TimeSlot.SLOT_16_00, 0);
+            List<BestMeetingTimeVo> candidateMeetingTimes = List.of(bestMeetingTimeVo);
+
+            BestMeetingTimeVo e1 = new BestMeetingTimeVo(availableDate, TimeSlot.SLOT_14_00, TimeSlot.SLOT_16_00, 0);
+            List<BestMeetingTimeVo> expected = List.of(e1);
+
+            // when
+            List<BestMeetingTimeVo> response = continuousMeetingTimeStrategy.find(candidateMeetingTimes, duration);
+
+            // then
+            assertThat(response).isEqualTo(expected);
+        }
+
+
+        @DisplayName("14:00 - 20:00 returns 14:00 - 16:00, 18:00 - 20:00")
+        @Test
+        void test2() {
+            // given
+            LocalDate availableDate = LocalDate.of(2023, 7, 10);
+            BestMeetingTimeVo bestMeetingTimeVo =
+                    new BestMeetingTimeVo(availableDate, TimeSlot.SLOT_14_00, TimeSlot.SLOT_20_00, 0);
+            List<BestMeetingTimeVo> candidateMeetingTimes = List.of(bestMeetingTimeVo);
+
+            BestMeetingTimeVo e1 = new BestMeetingTimeVo(availableDate, TimeSlot.SLOT_14_00, TimeSlot.SLOT_16_00, 0);
+            BestMeetingTimeVo e2 = new BestMeetingTimeVo(availableDate, TimeSlot.SLOT_18_00, TimeSlot.SLOT_20_00, 0);
+            List<BestMeetingTimeVo> expected = List.of(e1, e2);
+
+            // when
+            List<BestMeetingTimeVo> response = continuousMeetingTimeStrategy.find(candidateMeetingTimes, duration);
+
+            // then
+            assertThat(response).isEqualTo(expected);
+        }
+    }
+
+    @DisplayName("회의 진행 시간이 2시간 30분인 경우, 7시간 이상인 블록은 긴 블록으로 처리한다.")
+    @Nested
+    class DurationTwoHourHalfTest {
+        Duration duration = Duration.TWO_HOUR_HALF;
+
+        @DisplayName("14:00 - 17:00 returns 14:00 - 16:30")
+        @Test
+        void test() {
+            // given
+            LocalDate availableDate = LocalDate.of(2023, 7, 10);
+            BestMeetingTimeVo bestMeetingTimeVo =
+                    new BestMeetingTimeVo(availableDate, TimeSlot.SLOT_14_00, TimeSlot.SLOT_17_00, 0);
+            List<BestMeetingTimeVo> candidateMeetingTimes = List.of(bestMeetingTimeVo);
+
+            BestMeetingTimeVo e1 = new BestMeetingTimeVo(availableDate, TimeSlot.SLOT_14_00, TimeSlot.SLOT_16_30, 0);
+            List<BestMeetingTimeVo> expected = List.of(e1);
+
+            // when
+            List<BestMeetingTimeVo> response = continuousMeetingTimeStrategy.find(candidateMeetingTimes, duration);
+
+            // then
+            assertThat(response).isEqualTo(expected);
+        }
+
+        @DisplayName("14:00 - 21:00 returns 14:00 - 16:30, 19:30 - 21:00")
+        @Test
+        void test2() {
+            // given
+            LocalDate availableDate = LocalDate.of(2023, 7, 10);
+            BestMeetingTimeVo bestMeetingTimeVo =
+                    new BestMeetingTimeVo(availableDate, TimeSlot.SLOT_14_00, TimeSlot.SLOT_21_00, 0);
+            List<BestMeetingTimeVo> candidateMeetingTimes = List.of(bestMeetingTimeVo);
+
+            BestMeetingTimeVo e1 = new BestMeetingTimeVo(availableDate, TimeSlot.SLOT_14_00, TimeSlot.SLOT_16_30, 0);
+            BestMeetingTimeVo e2 = new BestMeetingTimeVo(availableDate, TimeSlot.SLOT_18_30, TimeSlot.SLOT_21_00, 0);
+            List<BestMeetingTimeVo> expected = List.of(e1, e2);
+
+            // when
+            List<BestMeetingTimeVo> response = continuousMeetingTimeStrategy.find(candidateMeetingTimes, duration);
+
+            // then
+            assertThat(response).isEqualTo(expected);
+        }
+    }
+
+    @DisplayName("회의 진행 시간이 3시간인 경우, 8시간 이상인 블록은 긴 블록으로 처리한다.")
+    @Nested
+    class DurationThreeHourTest {
+        Duration duration = Duration.THREE_HOUR;
+
+        @DisplayName("14:00 - 17:00 returns 14:00 - 17:00")
+        @Test
+        void test() {
+            // given
+            LocalDate availableDate = LocalDate.of(2023, 7, 10);
+            BestMeetingTimeVo bestMeetingTimeVo =
+                    new BestMeetingTimeVo(availableDate, TimeSlot.SLOT_14_00, TimeSlot.SLOT_17_00, 0);
+            List<BestMeetingTimeVo> candidateMeetingTimes = List.of(bestMeetingTimeVo);
+
+            BestMeetingTimeVo e1 = new BestMeetingTimeVo(availableDate, TimeSlot.SLOT_14_00, TimeSlot.SLOT_17_00, 0);
+            List<BestMeetingTimeVo> expected = List.of(e1);
+
+            // when
+            List<BestMeetingTimeVo> response = continuousMeetingTimeStrategy.find(candidateMeetingTimes, duration);
+
+            // then
+            assertThat(response).isEqualTo(expected);
+        }
+        
+        @DisplayName("14:00 - 22:00 returns 14:00 - 17:00, 19:00 - 22:00")
+        @Test
+        void test2() {
+            // given
+            LocalDate availableDate = LocalDate.of(2023, 7, 10);
+            BestMeetingTimeVo bestMeetingTimeVo =
+                    new BestMeetingTimeVo(availableDate, TimeSlot.SLOT_14_00, TimeSlot.SLOT_22_00, 0);
+            List<BestMeetingTimeVo> candidateMeetingTimes = List.of(bestMeetingTimeVo);
+
+            BestMeetingTimeVo e1 = new BestMeetingTimeVo(availableDate, TimeSlot.SLOT_14_00, TimeSlot.SLOT_17_00, 0);
+            BestMeetingTimeVo e2 = new BestMeetingTimeVo(availableDate, TimeSlot.SLOT_19_00, TimeSlot.SLOT_22_00, 0);
+            List<BestMeetingTimeVo> expected = List.of(e1, e2);
+
+            // when
+            List<BestMeetingTimeVo> response = continuousMeetingTimeStrategy.find(candidateMeetingTimes, duration);
+
+            // then
+            assertThat(response).isEqualTo(expected);
+        }
+    }
+}

--- a/src/test/java/com/asap/server/service/meeting/recommend/strategy/impl/BestMeetingTimeStrategyImplTest.java
+++ b/src/test/java/com/asap/server/service/meeting/recommend/strategy/impl/BestMeetingTimeStrategyImplTest.java
@@ -58,6 +58,29 @@ class BestMeetingTimeStrategyImplTest {
             // then
             assertThat(response).isEqualTo(expected);
         }
+
+        @DisplayName("6:00 - 6:30, 21:00 - 24:00 returns 6:00 - 6:30, 21:00 - 21:30, 23:30 - 24:00")
+        @Test
+        void test3() {
+            // given
+            LocalDate availableDate = LocalDate.of(2023, 7, 10);
+            BestMeetingTimeVo bestMeetingTimeVo =
+                    new BestMeetingTimeVo(availableDate, TimeSlot.SLOT_6_00, TimeSlot.SLOT_6_30, 0);
+            BestMeetingTimeVo bestMeetingTimeVo2 =
+                    new BestMeetingTimeVo(availableDate, TimeSlot.SLOT_21_00, TimeSlot.SLOT_24_00, 0);
+            List<BestMeetingTimeVo> candidateMeetingTimes = List.of(bestMeetingTimeVo, bestMeetingTimeVo2);
+
+            BestMeetingTimeVo e1 = new BestMeetingTimeVo(availableDate, TimeSlot.SLOT_6_00, TimeSlot.SLOT_6_30, 0);
+            BestMeetingTimeVo e2 = new BestMeetingTimeVo(availableDate, TimeSlot.SLOT_21_00, TimeSlot.SLOT_21_30, 0);
+            BestMeetingTimeVo e3 = new BestMeetingTimeVo(availableDate, TimeSlot.SLOT_23_30, TimeSlot.SLOT_24_00, 0);
+            List<BestMeetingTimeVo> expected = List.of(e1, e2, e3);
+
+            // when
+            List<BestMeetingTimeVo> response = continuousMeetingTimeStrategy.find(candidateMeetingTimes, duration);
+
+            // then
+            assertThat(response).isEqualTo(expected);
+        }
     }
 
     @DisplayName("회의 진행 시간이 1시간인 경우, 4시간 이상인 블록은 긴 블록으로 처리한다.")
@@ -264,7 +287,7 @@ class BestMeetingTimeStrategyImplTest {
             // then
             assertThat(response).isEqualTo(expected);
         }
-        
+
         @DisplayName("14:00 - 22:00 returns 14:00 - 17:00, 19:00 - 22:00")
         @Test
         void test2() {


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #293 

## Key Changes 🔑
1. 내용
   - 해당 시간대의 회의 진행 시간만큼의 상단의 회의 시간을 반환하고, 만약 긴 시간대라면 하단의 회의 시간을 반환하는 구현체입니다.

- 수도 코드

```
bestMeetingTimes = emptyList()
for candidateMeetingTime: candidateMeetingTimes
	[시작 시간 ~ 시작 시간 +duration]까지 BestMeetingTimeVo 생성 및 추가
	if 긴 블록이라면 [마지막 시간 - duration ~ 끝 시간]까지 BestMeetingTimeVo 생성 및 추가
return bestMeetingTimes 
```

```
bestMeetingTimes = emptyList()
for candidateMeetingTime: candidateMeetingTimes
	BestMeetingTimeVo <- startTime.index ~ startTime.index + duration
	add(firstTime);
	if endTime.index - startTime.index < duration 별 needBlock / 긴 블록이라면
		BestMeetingTimeVo <-  endTime.index - duration ~ endTime.index
		add(endTime);
return bestMeetingTimes 
```

## To Reviewers 📢
- DisplayName 기입 방식을 이전과 다르게 간단하게 표현해봤습니다. 이전과 비교했을 때, 지금 방식이 더 가독성이 좋은지 궁금합니다.

이전
```
@DisplayName("회의 진행 시간이 2시간 30분 이상 3시간 미만일 때, 2023-7-11일 14시 30분부터 17시까지인 BestMeetingTimeVo를 반환한다.")
```

현재
```
@DisplayName("14:00 - 16:00 returns 14:00 - 14:30")
```
