### PR TITLE
#307 [refactor] 로그인 기능 로그인 서비스로 분리

### DIFF
--- a/src/main/java/com/asap/server/common/exception/model/HostTimeForbiddenException.java
+++ b/src/main/java/com/asap/server/common/exception/model/HostTimeForbiddenException.java
@@ -6,9 +6,9 @@ import lombok.Getter;
 
 @Getter
 public class HostTimeForbiddenException extends AsapException {
-    private final HostLoginResponseDto data;
+    private final String data;
 
-    public HostTimeForbiddenException(Error error, HostLoginResponseDto data) {
+    public HostTimeForbiddenException(Error error, String data) {
         super(error);
         this.data = data;
     }

--- a/src/main/java/com/asap/server/common/exception/model/HostTimeForbiddenException.java
+++ b/src/main/java/com/asap/server/common/exception/model/HostTimeForbiddenException.java
@@ -1,6 +1,5 @@
 package com.asap.server.common.exception.model;
 
-import com.asap.server.presentation.controller.dto.response.HostLoginResponseDto;
 import com.asap.server.common.exception.Error;
 import lombok.Getter;
 
@@ -8,7 +7,7 @@ import lombok.Getter;
 public class HostTimeForbiddenException extends AsapException {
     private final String data;
 
-    public HostTimeForbiddenException(Error error, String data) {
+    public HostTimeForbiddenException(final Error error, final String data) {
         super(error);
         this.data = data;
     }

--- a/src/main/java/com/asap/server/presentation/common/advice/ControllerExceptionAdvice.java
+++ b/src/main/java/com/asap/server/presentation/common/advice/ControllerExceptionAdvice.java
@@ -104,7 +104,8 @@ public class ControllerExceptionAdvice {
     @ResponseStatus(HttpStatus.FORBIDDEN)
     @ExceptionHandler(HostTimeForbiddenException.class)
     protected ErrorDataResponse<HostLoginResponseDto> handleForbiddenException(final HostTimeForbiddenException e) {
-        return ErrorDataResponse.error(e.getError(), e.getMessage(), e.getData());
+        HostLoginResponseDto body = new HostLoginResponseDto(e.getData());
+        return ErrorDataResponse.error(e.getError(), e.getMessage(), body);
     }
 
     /**

--- a/src/main/java/com/asap/server/presentation/controller/dto/request/HostLoginRequestDto.java
+++ b/src/main/java/com/asap/server/presentation/controller/dto/request/HostLoginRequestDto.java
@@ -1,24 +1,19 @@
 package com.asap.server.presentation.controller.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
-@Getter
-@NoArgsConstructor
 @Schema(description = "방장 로그인 DTO")
-public class HostLoginRequestDto {
-    @NotBlank
-    @Size(max = 8 , message = "방장 이름의 최대 입력 길이(8자)를 초과했습니다.")
-    @Schema(description = "방장 이름", example = "김아삽")
-    private String name;
-
-    @NotBlank
-    @Pattern(regexp = "\\d{4,}", message = "비밀번호는 4자리 이상 숫자입니다.")
-    @Schema(description = "회의 비밀번호", example = "0808")
-    private String password;
+public record HostLoginRequestDto(
+        @NotBlank
+        @Size(max = 8, message = "방장 이름의 최대 입력 길이(8자)를 초과했습니다.")
+        @Schema(description = "방장 이름", example = "김아삽")
+        String name,
+        @NotBlank
+        @Pattern(regexp = "\\d{4,}", message = "비밀번호는 4자리 이상 숫자입니다.")
+        @Schema(description = "회의 비밀번호", example = "0808")
+        String password
+) {
 }

--- a/src/main/java/com/asap/server/presentation/controller/dto/response/HostLoginResponseDto.java
+++ b/src/main/java/com/asap/server/presentation/controller/dto/response/HostLoginResponseDto.java
@@ -1,14 +1,4 @@
 package com.asap.server.presentation.controller.dto.response;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.ToString;
-
-@Getter
-@Builder
-@ToString
-@AllArgsConstructor
-public class HostLoginResponseDto {
-    private String accessToken;
+public record HostLoginResponseDto(String accessToken) {
 }

--- a/src/main/java/com/asap/server/presentation/controller/user/UserRegisterController.java
+++ b/src/main/java/com/asap/server/presentation/controller/user/UserRegisterController.java
@@ -26,9 +26,15 @@ public class UserRegisterController implements UserRegisterControllerDocs {
             @MeetingPathVariable final Long meetingId,
             @RequestBody @Valid final HostLoginRequestDto requestDto
     ) {
+        String hostAccessToken = userLoginService.loginByHost(
+                meetingId,
+                requestDto.name(),
+                requestDto.password()
+        );
+
         return SuccessResponse.success(
                 Success.LOGIN_SUCCESS,
-                userLoginService.loginByHost(meetingId, requestDto.getName(), requestDto.getPassword())
+                new HostLoginResponseDto(hostAccessToken)
         );
     }
 }

--- a/src/main/java/com/asap/server/presentation/controller/user/UserRegisterController.java
+++ b/src/main/java/com/asap/server/presentation/controller/user/UserRegisterController.java
@@ -6,10 +6,9 @@ import com.asap.server.presentation.config.resolver.meeting.MeetingPathVariable;
 import com.asap.server.presentation.controller.dto.request.HostLoginRequestDto;
 import com.asap.server.presentation.controller.dto.response.HostLoginResponseDto;
 import com.asap.server.presentation.controller.user.docs.UserRegisterControllerDocs;
-import com.asap.server.service.UserService;
+import com.asap.server.service.user.UserLoginService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/user")
 @RequiredArgsConstructor
 public class UserRegisterController implements UserRegisterControllerDocs {
-    private final UserService userService;
+    private final UserLoginService userLoginService;
 
     @PostMapping("{meetingId}/host")
     @Override
@@ -27,6 +26,9 @@ public class UserRegisterController implements UserRegisterControllerDocs {
             @MeetingPathVariable final Long meetingId,
             @RequestBody @Valid final HostLoginRequestDto requestDto
     ) {
-        return SuccessResponse.success(Success.LOGIN_SUCCESS, userService.loginByHost(meetingId, requestDto));
+        return SuccessResponse.success(
+                Success.LOGIN_SUCCESS,
+                userLoginService.loginByHost(meetingId, requestDto.getName(), requestDto.getPassword())
+        );
     }
 }

--- a/src/main/java/com/asap/server/service/UserService.java
+++ b/src/main/java/com/asap/server/service/UserService.java
@@ -1,42 +1,36 @@
 package com.asap.server.service;
 
+import static com.asap.server.common.exception.Error.INVALID_MEETING_HOST_EXCEPTION;
+import static com.asap.server.common.exception.Error.USER_NOT_FOUND_EXCEPTION;
+
+import com.asap.server.common.exception.Error;
+import com.asap.server.common.exception.model.BadRequestException;
+import com.asap.server.common.exception.model.ConflictException;
+import com.asap.server.common.exception.model.NotFoundException;
+import com.asap.server.common.exception.model.UnauthorizedException;
 import com.asap.server.common.jwt.JwtService;
-import com.asap.server.presentation.controller.dto.request.AvailableTimeRequestDto;
-import com.asap.server.presentation.controller.dto.request.HostLoginRequestDto;
-import com.asap.server.presentation.controller.dto.request.UserMeetingTimeSaveRequestDto;
-import com.asap.server.presentation.controller.dto.request.UserRequestDto;
-import com.asap.server.presentation.controller.dto.response.HostLoginResponseDto;
-import com.asap.server.presentation.controller.dto.response.UserMeetingTimeResponseDto;
-import com.asap.server.presentation.controller.dto.response.UserTimeResponseDto;
 import com.asap.server.persistence.domain.AvailableDate;
 import com.asap.server.persistence.domain.Meeting;
 import com.asap.server.persistence.domain.User;
 import com.asap.server.persistence.domain.enums.Role;
 import com.asap.server.persistence.domain.enums.TimeSlot;
-import com.asap.server.common.exception.Error;
-import com.asap.server.common.exception.model.BadRequestException;
-import com.asap.server.common.exception.model.ConflictException;
-import com.asap.server.common.exception.model.HostTimeForbiddenException;
-import com.asap.server.common.exception.model.NotFoundException;
-import com.asap.server.common.exception.model.UnauthorizedException;
 import com.asap.server.persistence.repository.meeting.MeetingRepository;
 import com.asap.server.persistence.repository.user.UserRepository;
+import com.asap.server.presentation.controller.dto.request.AvailableTimeRequestDto;
+import com.asap.server.presentation.controller.dto.request.UserMeetingTimeSaveRequestDto;
+import com.asap.server.presentation.controller.dto.request.UserRequestDto;
+import com.asap.server.presentation.controller.dto.response.UserMeetingTimeResponseDto;
+import com.asap.server.presentation.controller.dto.response.UserTimeResponseDto;
 import com.asap.server.service.vo.BestMeetingTimeVo;
 import com.asap.server.service.vo.BestMeetingTimeWithUsersVo;
 import com.asap.server.service.vo.UserVo;
-import lombok.RequiredArgsConstructor;
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-
-import static com.asap.server.common.exception.Error.INVALID_MEETING_HOST_EXCEPTION;
-import static com.asap.server.common.exception.Error.MEETING_VALIDATION_FAILED_EXCEPTION;
-import static com.asap.server.common.exception.Error.USER_NOT_FOUND_EXCEPTION;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 
 @Service

--- a/src/main/java/com/asap/server/service/user/UserLoginService.java
+++ b/src/main/java/com/asap/server/service/user/UserLoginService.java
@@ -10,7 +10,6 @@ import com.asap.server.common.exception.model.UnauthorizedException;
 import com.asap.server.common.jwt.JwtService;
 import com.asap.server.persistence.domain.Meeting;
 import com.asap.server.persistence.repository.meeting.MeetingRepository;
-import com.asap.server.presentation.controller.dto.response.HostLoginResponseDto;
 import com.asap.server.service.TimeBlockUserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -26,7 +25,7 @@ public class UserLoginService {
     private final TimeBlockUserService timeBlockUserService;
 
     @Transactional
-    public HostLoginResponseDto loginByHost(
+    public String loginByHost(
             final Long meetingId,
             final String name,
             final String password
@@ -46,14 +45,12 @@ public class UserLoginService {
             throw new ConflictException(MEETING_VALIDATION_FAILED_EXCEPTION);
         }
 
-        HostLoginResponseDto responseDto = new HostLoginResponseDto(
-                jwtService.issuedToken(meeting.getHost().getId().toString())
-        );
+        String hostAccessToken = jwtService.issuedToken(meeting.getHost().getId().toString());
 
         if (timeBlockUserService.isEmptyHostTimeBlock(meeting.getHost())) {
-            throw new HostTimeForbiddenException(Error.HOST_MEETING_TIME_NOT_PROVIDED, responseDto);
+            throw new HostTimeForbiddenException(Error.HOST_MEETING_TIME_NOT_PROVIDED, hostAccessToken);
         }
 
-        return responseDto;
+        return hostAccessToken;
     }
 }

--- a/src/main/java/com/asap/server/service/user/UserLoginService.java
+++ b/src/main/java/com/asap/server/service/user/UserLoginService.java
@@ -1,0 +1,59 @@
+package com.asap.server.service.user;
+
+import static com.asap.server.common.exception.Error.MEETING_VALIDATION_FAILED_EXCEPTION;
+
+import com.asap.server.common.exception.Error;
+import com.asap.server.common.exception.model.ConflictException;
+import com.asap.server.common.exception.model.HostTimeForbiddenException;
+import com.asap.server.common.exception.model.NotFoundException;
+import com.asap.server.common.exception.model.UnauthorizedException;
+import com.asap.server.common.jwt.JwtService;
+import com.asap.server.persistence.domain.Meeting;
+import com.asap.server.persistence.repository.meeting.MeetingRepository;
+import com.asap.server.presentation.controller.dto.response.HostLoginResponseDto;
+import com.asap.server.service.TimeBlockUserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserLoginService {
+    private final MeetingRepository meetingRepository;
+    private final JwtService jwtService;
+    private final PasswordEncoder passwordEncoder;
+    private final TimeBlockUserService timeBlockUserService;
+
+    @Transactional
+    public HostLoginResponseDto loginByHost(
+            final Long meetingId,
+            final String name,
+            final String password
+    ) {
+        Meeting meeting = meetingRepository.findByIdWithHost(meetingId)
+                .orElseThrow(() -> new NotFoundException(Error.MEETING_NOT_FOUND_EXCEPTION));
+
+        if (!meeting.checkHostName(name)) {
+            throw new UnauthorizedException(Error.INVALID_HOST_ID_PASSWORD_EXCEPTION);
+        }
+
+        if (!passwordEncoder.matches(password, meeting.getPassword())) {
+            throw new UnauthorizedException(Error.INVALID_HOST_ID_PASSWORD_EXCEPTION);
+        }
+
+        if (meeting.isConfirmedMeeting()) {
+            throw new ConflictException(MEETING_VALIDATION_FAILED_EXCEPTION);
+        }
+
+        HostLoginResponseDto responseDto = new HostLoginResponseDto(
+                jwtService.issuedToken(meeting.getHost().getId().toString())
+        );
+
+        if (timeBlockUserService.isEmptyHostTimeBlock(meeting.getHost())) {
+            throw new HostTimeForbiddenException(Error.HOST_MEETING_TIME_NOT_PROVIDED, responseDto);
+        }
+
+        return responseDto;
+    }
+}

--- a/src/test/java/com/asap/server/presentation/controller/user/UserRegisterControllerTest.java
+++ b/src/test/java/com/asap/server/presentation/controller/user/UserRegisterControllerTest.java
@@ -1,0 +1,113 @@
+package com.asap.server.presentation.controller.user;
+
+import static com.asap.server.common.exception.Error.HOST_MEETING_TIME_NOT_PROVIDED;
+import static com.asap.server.common.exception.Error.INVALID_HOST_ID_PASSWORD_EXCEPTION;
+import static com.asap.server.common.exception.Error.MEETING_VALIDATION_FAILED_EXCEPTION;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.asap.server.common.exception.model.ConflictException;
+import com.asap.server.common.exception.model.HostTimeForbiddenException;
+import com.asap.server.common.exception.model.UnauthorizedException;
+import com.asap.server.presentation.controller.dto.request.HostLoginRequestDto;
+import com.asap.server.service.user.UserLoginService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class UserRegisterControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @MockBean
+    private UserLoginService userLoginService;
+
+    @DisplayName("아직 확정되지 않은 특정 회의의 방장의 이름과 비밀번호가 일치하면 200 응답과 accessToken을 반환한다.")
+    @Test
+    void test() throws Exception {
+        // given
+        String encodedMeetingId = "MQ==";
+        HostLoginRequestDto bodyDto = new HostLoginRequestDto("KWY", "0000");
+        String body = objectMapper.writeValueAsString(bodyDto);
+        when(userLoginService.loginByHost(1L, "KWY", "0000")).thenReturn("access token");
+
+        mockMvc.perform(
+                        post("/user/" + encodedMeetingId + "/host")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(body)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("로그인 성공입니다"))
+                .andExpect(jsonPath("$.data.accessToken").value("access token"));
+    }
+
+    @DisplayName("방장 이름 또는 특정 회의의 비밀번호가 일치하지 않는다면 401 에러를 반환한다.")
+    @Test
+    void test2() throws Exception {
+        // given
+        String encodedMeetingId = "MQ==";
+        HostLoginRequestDto bodyDto = new HostLoginRequestDto("USER1", "0000");
+        String body = objectMapper.writeValueAsString(bodyDto);
+        when(userLoginService.loginByHost(1L, "USER1", "0000"))
+                .thenThrow(new UnauthorizedException(INVALID_HOST_ID_PASSWORD_EXCEPTION));
+
+        mockMvc.perform(
+                        post("/user/" + encodedMeetingId + "/host")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(body)
+                )
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.message").value("유효하지 않은 사용자 이름 또는 비밀번호입니다."));
+    }
+
+    @DisplayName("이미 확정된 회의라면 409 에러를 반환한다.")
+    @Test
+    void test3() throws Exception {
+        // given
+        String encodedMeetingId = "MQ==";
+        HostLoginRequestDto bodyDto = new HostLoginRequestDto("KWY", "0000");
+        String body = objectMapper.writeValueAsString(bodyDto);
+        when(userLoginService.loginByHost(1L, "KWY", "0000"))
+                .thenThrow(new ConflictException(MEETING_VALIDATION_FAILED_EXCEPTION));
+
+        mockMvc.perform(
+                        post("/user/" + encodedMeetingId + "/host")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(body)
+                )
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.message").value("이미 확정된 회의입니다."));
+    }
+
+    @DisplayName("방장이 시간을 입력하지 않았다면 403 에러와 함께 jwt 토큰을 반환한다.")
+    @Test
+    void test4() throws Exception {
+        // given
+        String encodedMeetingId = "MQ==";
+        HostLoginRequestDto bodyDto = new HostLoginRequestDto("KWY", "0000");
+        String body = objectMapper.writeValueAsString(bodyDto);
+        when(userLoginService.loginByHost(1L, "KWY", "0000"))
+                .thenThrow(new HostTimeForbiddenException(HOST_MEETING_TIME_NOT_PROVIDED, "access token"));
+
+        mockMvc.perform(
+                        post("/user/" + encodedMeetingId + "/host")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(body)
+                )
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.message").value("회의 가능 시간이 입력되지 않았습니다."))
+                .andExpect(jsonPath("$.data.accessToken").value("access token"));
+    }
+}

--- a/src/test/java/com/asap/server/service/user/UserLoginServiceTest.java
+++ b/src/test/java/com/asap/server/service/user/UserLoginServiceTest.java
@@ -1,0 +1,65 @@
+package com.asap.server.service.user;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.asap.server.common.jwt.JwtService;
+import com.asap.server.persistence.domain.Meeting;
+import com.asap.server.persistence.domain.User;
+import com.asap.server.persistence.domain.enums.Role;
+import com.asap.server.persistence.repository.meeting.MeetingRepository;
+import com.asap.server.presentation.controller.dto.response.HostLoginResponseDto;
+import com.asap.server.service.TimeBlockUserService;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class UserLoginServiceTest {
+    @Mock
+    private MeetingRepository meetingRepository;
+    @Mock
+    private JwtService jwtService;
+    @Mock
+    private PasswordEncoder passwordEncoder;
+    @Mock
+    private TimeBlockUserService timeBlockUserService;
+    @InjectMocks
+    UserLoginService userLoginService;
+
+    @Test
+    @DisplayName("아직 확정되지 않은 특정 회의의 방장의 이름과 비밀번호가 일치하면 accessToken을 반환한다.")
+    void test() {
+        // given
+        long meetingId = 1L;
+        final Meeting meeting = Meeting.builder()
+                .id(meetingId)
+                .password("0000")
+                .build();
+        final User host = User.builder()
+                .id(1L)
+                .meeting(meeting)
+                .name("KWY")
+                .role(Role.HOST)
+                .isFixed(false)
+                .build();
+        meeting.setHost(host);
+        when(meetingRepository.findByIdWithHost(meetingId)).thenReturn(Optional.of(meeting));
+        when(passwordEncoder.matches(meeting.getPassword(), "0000")).thenReturn(true);
+        when(timeBlockUserService.isEmptyHostTimeBlock(host)).thenReturn(false);
+        when(jwtService.issuedToken("1")).thenReturn("access token");
+        
+        HostLoginResponseDto expected = new HostLoginResponseDto("access token");
+
+        // when
+        HostLoginResponseDto response = userLoginService.loginByHost(meetingId, "KWY", "0000");
+
+        // then
+        assertThat(response).isEqualTo(expected);
+    }
+}

--- a/src/test/java/com/asap/server/service/user/UserLoginServiceTest.java
+++ b/src/test/java/com/asap/server/service/user/UserLoginServiceTest.java
@@ -13,7 +13,6 @@ import com.asap.server.persistence.domain.Meeting;
 import com.asap.server.persistence.domain.User;
 import com.asap.server.persistence.domain.enums.Role;
 import com.asap.server.persistence.repository.meeting.MeetingRepository;
-import com.asap.server.presentation.controller.dto.response.HostLoginResponseDto;
 import com.asap.server.service.TimeBlockUserService;
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -71,7 +70,7 @@ class UserLoginServiceTest {
         when(timeBlockUserService.isEmptyHostTimeBlock(host)).thenReturn(false);
         when(jwtService.issuedToken("1")).thenReturn("access token");
 
-        HostLoginResponseDto expected = new HostLoginResponseDto("access token");
+        String expected = "access token";
 
         // when
         String response = userLoginService.loginByHost(meetingId, "KWY", "0000");

--- a/src/test/java/com/asap/server/service/user/UserLoginServiceTest.java
+++ b/src/test/java/com/asap/server/service/user/UserLoginServiceTest.java
@@ -74,7 +74,7 @@ class UserLoginServiceTest {
         HostLoginResponseDto expected = new HostLoginResponseDto("access token");
 
         // when
-        HostLoginResponseDto response = userLoginService.loginByHost(meetingId, "KWY", "0000");
+        String response = userLoginService.loginByHost(meetingId, "KWY", "0000");
 
         // then
         assertThat(response).isEqualTo(expected);


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #307 

## Key Changes 🔑
1. 내용
   - 모든 기능을 user service에 넣는 것이 아닌 하나의 서비스가 하나의 역할을 할 수 있도록 만들기 위해 별도의 로그인 서비스를 추가로 생성했습니다
   - presentation 계층, service 계층 테스트 코드 추가했습니다.
   - presentation 계층 테스트를 WebMvcTest를 사용해서 slice test를 하고 싶었는데, interceptor 등 추가로 넣어야 하는 bean들이 많아서 springboottest로 했습니다..
