### PR TITLE
#326 [fix] 시간 별 유저 조회 로직 수정

### DIFF
--- a/src/main/java/com/asap/server/service/time/UserMeetingScheduleService.java
+++ b/src/main/java/com/asap/server/service/time/UserMeetingScheduleService.java
@@ -86,7 +86,7 @@ public class UserMeetingScheduleService {
     ) {
         return TimeSlot.getTimeSlots(
                         userMeetingSchedule.getStartTimeSlot().getIndex(),
-                        userMeetingSchedule.getEndTimeSlot().getIndex()
+                        userMeetingSchedule.getEndTimeSlot().getIndex() - 1
                 )
                 .stream()
                 .map(timeSlot -> new UserScheduleByTimeSlotVo(

--- a/src/test/java/com/asap/server/service/time/UserMeetingScheduleServiceTest.java
+++ b/src/test/java/com/asap/server/service/time/UserMeetingScheduleServiceTest.java
@@ -25,7 +25,7 @@ class UserMeetingScheduleServiceTest {
     private UserMeetingScheduleService userMeetingScheduleService;
 
     @Test
-    @DisplayName("시간별로 사용자를 구할 수 있다.")
+    @DisplayName("input 6:00 - 08:00 , return 06:00 - 07:30")
     void test() {
         // given
         UserMeetingSchedule userMeetingSchedule = UserMeetingSchedule
@@ -51,8 +51,7 @@ class UserMeetingScheduleServiceTest {
                 new TimeBlockVo(LocalDate.of(2024, 7, 9), TimeSlot.SLOT_6_00, 0, List.of(1L, 2L)),
                 new TimeBlockVo(LocalDate.of(2024, 7, 9), TimeSlot.SLOT_6_30, 0, List.of(1L, 2L)),
                 new TimeBlockVo(LocalDate.of(2024, 7, 9), TimeSlot.SLOT_7_00, 0, List.of(1L, 2L)),
-                new TimeBlockVo(LocalDate.of(2024, 7, 9), TimeSlot.SLOT_7_30, 0, List.of(1L, 2L)),
-                new TimeBlockVo(LocalDate.of(2024, 7, 9), TimeSlot.SLOT_8_00, 0, List.of(1L, 2L))
+                new TimeBlockVo(LocalDate.of(2024, 7, 9), TimeSlot.SLOT_7_30, 0, List.of(1L, 2L))
         );
 
         // when
@@ -63,7 +62,7 @@ class UserMeetingScheduleServiceTest {
     }
 
     @Test
-    @DisplayName("빈 리스트를 반환할 때 시간 블록이 비어있는지 확인한다.")
+    @DisplayName("input empty list , return empty list")
     void test2() {
         // given
         when(userMeetingScheduleRepository.findAllByMeetingId(1L)).thenReturn(Collections.emptyList());
@@ -76,7 +75,7 @@ class UserMeetingScheduleServiceTest {
     }
 
     @Test
-    @DisplayName("가중치를 고려해서 시간별로 사용자를 구할 수 있다.")
+    @DisplayName("input [06:00 - 07:00, 가중치: 1], [06:00 - 08:00, 가중치: 2], return [06:00 - 06:30 가중치 3], [07:00 - 07:30 가중치 2]")
     void test3() {
         // given
         UserMeetingSchedule userMeetingSchedule = UserMeetingSchedule
@@ -103,9 +102,62 @@ class UserMeetingScheduleServiceTest {
         List<TimeBlockVo> expected = List.of(
                 new TimeBlockVo(LocalDate.of(2024, 7, 9), TimeSlot.SLOT_6_00, 3, List.of(1L, 2L)),
                 new TimeBlockVo(LocalDate.of(2024, 7, 9), TimeSlot.SLOT_6_30, 3, List.of(1L, 2L)),
-                new TimeBlockVo(LocalDate.of(2024, 7, 9), TimeSlot.SLOT_7_00, 3, List.of(1L, 2L)),
-                new TimeBlockVo(LocalDate.of(2024, 7, 9), TimeSlot.SLOT_7_30, 2, List.of(2L)),
-                new TimeBlockVo(LocalDate.of(2024, 7, 9), TimeSlot.SLOT_8_00, 2, List.of(2L))
+                new TimeBlockVo(LocalDate.of(2024, 7, 9), TimeSlot.SLOT_7_00, 2, List.of(2L)),
+                new TimeBlockVo(LocalDate.of(2024, 7, 9), TimeSlot.SLOT_7_30, 2, List.of(2L))
+        );
+
+        // when
+        List<TimeBlockVo> response = userMeetingScheduleService.getTimeBlocks(1L);
+
+        // then
+        assertThat(response).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("input [유저 1: 10:00 - 13:30], [유저 2: 08:30 - 11:00, 11:00 - 13:00], return [08:30 - 09:30 유저 2], [10:00 - 12:30 유저 1,2], [13:00, 유저 1]")
+    void test4() {
+        // given
+        UserMeetingSchedule userMeetingSchedule = UserMeetingSchedule
+                .builder()
+                .userId(1L)
+                .availableDate(LocalDate.of(2024, 7, 9))
+                .startTimeSlot(TimeSlot.SLOT_10_00)
+                .endTimeSlot(TimeSlot.SLOT_13_30)
+                .weight(0)
+                .build();
+
+        UserMeetingSchedule userMeetingSchedule2 = UserMeetingSchedule
+                .builder()
+                .userId(2L)
+                .availableDate(LocalDate.of(2024, 7, 9))
+                .startTimeSlot(TimeSlot.SLOT_8_30)
+                .endTimeSlot(TimeSlot.SLOT_11_00)
+                .weight(0)
+                .build();
+        UserMeetingSchedule userMeetingSchedule3 = UserMeetingSchedule
+                .builder()
+                .userId(2L)
+                .availableDate(LocalDate.of(2024, 7, 9))
+                .startTimeSlot(TimeSlot.SLOT_11_00)
+                .endTimeSlot(TimeSlot.SLOT_13_00)
+                .weight(0)
+                .build();
+
+        List<UserMeetingSchedule> userMeetingSchedules =
+                List.of(userMeetingSchedule, userMeetingSchedule2, userMeetingSchedule3);
+        when(userMeetingScheduleRepository.findAllByMeetingId(1L)).thenReturn(userMeetingSchedules);
+
+        List<TimeBlockVo> expected = List.of(
+                new TimeBlockVo(LocalDate.of(2024, 7, 9), TimeSlot.SLOT_8_30, 0, List.of(2L)),
+                new TimeBlockVo(LocalDate.of(2024, 7, 9), TimeSlot.SLOT_9_00, 0, List.of(2L)),
+                new TimeBlockVo(LocalDate.of(2024, 7, 9), TimeSlot.SLOT_9_30, 0, List.of(2L)),
+                new TimeBlockVo(LocalDate.of(2024, 7, 9), TimeSlot.SLOT_10_00, 0, List.of(1L, 2L)),
+                new TimeBlockVo(LocalDate.of(2024, 7, 9), TimeSlot.SLOT_10_30, 0, List.of(1L, 2L)),
+                new TimeBlockVo(LocalDate.of(2024, 7, 9), TimeSlot.SLOT_11_00, 0, List.of(1L, 2L)),
+                new TimeBlockVo(LocalDate.of(2024, 7, 9), TimeSlot.SLOT_11_30, 0, List.of(1L, 2L)),
+                new TimeBlockVo(LocalDate.of(2024, 7, 9), TimeSlot.SLOT_12_00, 0, List.of(1L, 2L)),
+                new TimeBlockVo(LocalDate.of(2024, 7, 9), TimeSlot.SLOT_12_30, 0, List.of(1L, 2L)),
+                new TimeBlockVo(LocalDate.of(2024, 7, 9), TimeSlot.SLOT_13_00, 0, List.of(1L))
         );
 
         // when

--- a/src/test/java/com/asap/server/service/time/UserMeetingScheduleServiceTest.java
+++ b/src/test/java/com/asap/server/service/time/UserMeetingScheduleServiceTest.java
@@ -166,4 +166,58 @@ class UserMeetingScheduleServiceTest {
         // then
         assertThat(response).isEqualTo(expected);
     }
+
+    @Test
+    @DisplayName("input [유저 1: 6:00 - 6:30] return [06:00, 유저 1]")
+    void test5() {
+        // given
+        UserMeetingSchedule userMeetingSchedule = UserMeetingSchedule
+                .builder()
+                .userId(1L)
+                .availableDate(LocalDate.of(2024, 7, 9))
+                .startTimeSlot(TimeSlot.SLOT_6_00)
+                .endTimeSlot(TimeSlot.SLOT_6_30)
+                .weight(0)
+                .build();
+
+        List<UserMeetingSchedule> userMeetingSchedules = List.of(userMeetingSchedule);
+        when(userMeetingScheduleRepository.findAllByMeetingId(1L)).thenReturn(userMeetingSchedules);
+
+        List<TimeBlockVo> expected = List.of(
+                new TimeBlockVo(LocalDate.of(2024, 7, 9), TimeSlot.SLOT_6_00, 0, List.of(1L))
+        );
+
+        // when
+        List<TimeBlockVo> response = userMeetingScheduleService.getTimeBlocks(1L);
+
+        // then
+        assertThat(response).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("input [유저 1: 23:30 - 24:00] return [23:30, 유저 1]")
+    void test6() {
+        // given
+        UserMeetingSchedule userMeetingSchedule = UserMeetingSchedule
+                .builder()
+                .userId(1L)
+                .availableDate(LocalDate.of(2024, 7, 9))
+                .startTimeSlot(TimeSlot.SLOT_23_30)
+                .endTimeSlot(TimeSlot.SLOT_24_00)
+                .weight(0)
+                .build();
+
+        List<UserMeetingSchedule> userMeetingSchedules = List.of(userMeetingSchedule);
+        when(userMeetingScheduleRepository.findAllByMeetingId(1L)).thenReturn(userMeetingSchedules);
+
+        List<TimeBlockVo> expected = List.of(
+                new TimeBlockVo(LocalDate.of(2024, 7, 9), TimeSlot.SLOT_23_30, 0, List.of(1L))
+        );
+
+        // when
+        List<TimeBlockVo> response = userMeetingScheduleService.getTimeBlocks(1L);
+
+        // then
+        assertThat(response).isEqualTo(expected);
+    }
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #326 

## Key Changes 🔑
1. 내용
   - 만약 사용자가 06:00 - 08:00 을 입력했다면, 실제 가능한 시간은 06:00, 06:30, 07:00, 07:30 입니다.
   지금까지 08:00를 반환해서 오류가 생겼고, 이를 수정했습니다.

## To Reviewers 📢
-
