### PR TITLE
#328 [fix] slack util deprecated api 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ dependencies {
     implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
 
     // Slack Webhook
-    implementation 'com.slack.api:slack-api-client:1.28.0'
+    implementation 'com.slack.api:slack-api-client:1.30.0'
     implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'com.squareup.okhttp3:okhttp:4.10.0'
     implementation 'com.slack.api:slack-app-backend:1.28.0'

--- a/src/main/java/com/asap/server/infra/slack/SlackUtil.java
+++ b/src/main/java/com/asap/server/infra/slack/SlackUtil.java
@@ -4,6 +4,7 @@ import com.slack.api.Slack;
 import com.slack.api.model.block.Blocks;
 import com.slack.api.model.block.LayoutBlock;
 import com.slack.api.model.block.composition.BlockCompositions;
+import com.slack.api.webhook.Payload;
 import com.slack.api.webhook.WebhookPayloads;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,29 +26,19 @@ public class SlackUtil {
 
     @Value("${slack.webhook.url}")
     private String webhookUrl;
-    private StringBuilder sb= new StringBuilder();
+    private final StringBuilder sb= new StringBuilder();
 
-    private String NEW_LINE = "\n";
-    private String DOUBLE_NEW_LINE = "\n\n";
+    private final String NEW_LINE = "\n";
+    private final String DOUBLE_NEW_LINE = "\n\n";
 
-    //slack으로 알림보내기
     public void sendAlert(Exception error, HttpServletRequest request) throws IOException{
-        // 메시지 내용인 LayoutBlock List 생성
-        List layoutBlocks= generateLayoutBlock(error,request);
+        List<LayoutBlock> layoutBlocks= generateLayoutBlock(error,request);
 
-        // 슬랙의 send API과 webhookURL을 통해 생성한 메시지 내용 전송
         Slack.getInstance().send(webhookUrl, WebhookPayloads
-                .payload(p->
-                        // 메시지 전송 유저명
-                        p.username("Exception is detected")
-                                // 메시지 전송 유저 아이콘 이미지 URL
-                                .iconUrl("https://yt3.googleusercontent.com/ytc/AGIKgqMVUzRrhoo1gDQcqvPo0PxaJz7e0gqDXT0D78R5VQ=s900-c-k-c0x00ffffff-no-rj")
-                                // 메시지 내용
-                                .blocks(layoutBlocks)));
+                .payload(p -> p.blocks(layoutBlocks)));
     }
 
-    // 전체 메시지가 담긴 LayoutBlock 생성
-    private List generateLayoutBlock(Exception error, HttpServletRequest request) {
+    private List<LayoutBlock> generateLayoutBlock(Exception error, HttpServletRequest request) {
         return Blocks.asBlocks(
                 getHeader("Internal Server Error Detected"),
                 Blocks.divider(),
@@ -55,44 +46,39 @@ public class SlackUtil {
                 Blocks.divider(),
                 getSection(generateErrorPointMessage(request)),
                 Blocks.divider(),
-                // 이슈 생성을 위해 프로젝트의 Issue URL을 입력하여 바로가기 링크를 생성
                 getSection("<https://github.com/ASAP-as-soon-as-posiible/ASAP_Server/issues | Go To Make Issue >")
         );
     }
 
 
-    // 예외 정보 메시지 생성
     private String generateErrorMessage(Exception error) {
         sb.setLength(0);
-        sb.append("*[Exception]*" + NEW_LINE + error.toString() + DOUBLE_NEW_LINE);
-        sb.append("*[From]*" + NEW_LINE + readRootStackTrace(error) + DOUBLE_NEW_LINE);
+        sb.append("*[Exception]*").append(NEW_LINE).append(error.toString()).append(DOUBLE_NEW_LINE);
+        sb.append("*[From]*").append(NEW_LINE).append(readRootStackTrace(error)).append(DOUBLE_NEW_LINE);
 
         return sb.toString();
     }
 
-    // HttpServletRequest를 사용하여 예외발생 요청에 대한 정보 메시지 생성
     private String generateErrorPointMessage(HttpServletRequest request) {
         sb.setLength(0);
-        sb.append("*[Details]*" + NEW_LINE);
-        sb.append("Request URL : " + request.getRequestURL().toString() + NEW_LINE);
-        sb.append("Request Method : " + request.getMethod() + NEW_LINE);
-        sb.append("Request Time : " + new Date() + NEW_LINE);
+        sb.append("*[Details]*").append(NEW_LINE);
+        sb.append("Request URL : ").append(request.getRequestURL().toString()).append(NEW_LINE);
+        sb.append("Request Method : ").append(request.getMethod()).append(NEW_LINE);
+        sb.append("Request Time : ").append(new Date()).append(NEW_LINE);
 
         return sb.toString();
     }
 
-    // 예외발생 클래스 정보 return
     private String readRootStackTrace(Exception error) {
         return error.getStackTrace()[0].toString();
     }
-    // 에러 로그 메시지의 제목 return
+
     private LayoutBlock getHeader(String text) {
         return Blocks.header(h->h.text(
                 plainText(pt->pt.emoji(true)
                         .text(text))));
     }
 
-    // 에러 로그 메시지 내용 return
     private LayoutBlock getSection(String message) {
         return Blocks.section(s->
                 s.text(BlockCompositions.markdownText(message)));

--- a/src/main/java/com/asap/server/persistence/domain/time/UserMeetingSchedule.java
+++ b/src/main/java/com/asap/server/persistence/domain/time/UserMeetingSchedule.java
@@ -1,5 +1,6 @@
 package com.asap.server.persistence.domain.time;
 
+import com.asap.server.persistence.domain.AuditingTimeEntity;
 import com.asap.server.persistence.domain.enums.TimeSlot;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -18,7 +19,7 @@ import org.hibernate.annotations.ColumnDefault;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class UserMeetingSchedule {
+public class UserMeetingSchedule extends AuditingTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #328 

## Key Changes 🔑
1. slack이 제공하는 의존성에서 보내는 사람을 지정하는 API가 deprecated 되고, slack 앱에서 지정하도록 변경됨에 따라 앱에서 지정 후 코드에서 제거하였습니다. 기존에 있던 주석들도 함께 지우고, String Builder 사용 방식도 수정하였습니다!

## To Reviewers 📢
-
