### PR TITLE
#330 [feat] 메트릭 api 구현

### DIFF
--- a/src/main/java/com/asap/server/common/exception/Error.java
+++ b/src/main/java/com/asap/server/common/exception/Error.java
@@ -21,7 +21,7 @@ public enum Error {
     INVALID_JSON_INPUT_EXCEPTION(HttpStatus.BAD_REQUEST, "입력 형식이 맞지 않습니다."),
     INVALID_TOKEN_EXCEPTION(HttpStatus.BAD_REQUEST, "유효하지 않은 토큰을 입력했습니다."),
     BAD_REQUEST_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 요청이 있습니다."),
-    INVALID_DATE_FORMAT_EXCEPTION(HttpStatus.BAD_REQUEST, "유요하지 않은 날짜를 입력했습니다."),
+    INVALID_DATE_FORMAT_EXCEPTION(HttpStatus.BAD_REQUEST, "유효하지 않은 날짜를 입력했습니다."),
     // user
     USERNAME_NOT_NULL_EXCEPTION(HttpStatus.BAD_REQUEST, "사용자 이름에는 null이 들어올 수 없습니다."),
     USERNAME_NOT_BLANK_EXCEPTION(HttpStatus.BAD_REQUEST, "사용자 이름에는 빈 값이 들어올 수 없습니다."),

--- a/src/main/java/com/asap/server/common/exception/Success.java
+++ b/src/main/java/com/asap/server/common/exception/Success.java
@@ -19,6 +19,7 @@ public enum Success {
     MEETING_VALIDATION_SUCCESS(HttpStatus.OK, "유효한 회의입니다."),
     LOGIN_SUCCESS(HttpStatus.OK, "로그인 성공입니다"),
     BEST_MEETING_SUCCESS(HttpStatus.OK, "최적의 회의시간 조회 성공입니다."),
+    GET_METRICS_SUCCESS(HttpStatus.OK, "메트릭 정보 조회 성공입니다."),
     /**
      * 201 CREATED SUCCESS
      */

--- a/src/main/java/com/asap/server/infra/slack/MetricsEvent.java
+++ b/src/main/java/com/asap/server/infra/slack/MetricsEvent.java
@@ -1,0 +1,6 @@
+package com.asap.server.infra.slack;
+
+import java.util.Map;
+
+public record MetricsEvent(Map<String, String> metrics) {
+}

--- a/src/main/java/com/asap/server/infra/slack/MetricsSlackEventListener.java
+++ b/src/main/java/com/asap/server/infra/slack/MetricsSlackEventListener.java
@@ -1,0 +1,60 @@
+package com.asap.server.infra.slack;
+
+import static com.slack.api.model.block.composition.BlockCompositions.plainText;
+
+import com.slack.api.Slack;
+import com.slack.api.model.block.Blocks;
+import com.slack.api.model.block.LayoutBlock;
+import com.slack.api.model.block.composition.BlockCompositions;
+import com.slack.api.webhook.WebhookPayloads;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MetricsSlackEventListener {
+    @Value("${slack.webhook.metrics-url}")
+    private String webhookUrl;
+
+    @Async
+    @EventListener
+    public void sendMetrics(final MetricsEvent metricsEvent) throws IOException {
+        List<LayoutBlock> layoutBlocks = generateLayoutBlock(metricsEvent.metrics());
+
+        Slack.getInstance().send(webhookUrl, WebhookPayloads
+                .payload(p -> p.blocks(layoutBlocks)));
+    }
+
+    private List<LayoutBlock> generateLayoutBlock(final Map<String, String> metrics) {
+        return Blocks.asBlocks(
+                getHeader("ASAP 데이터"),
+                Blocks.divider(),
+                getSection(generateMetricsMessage(metrics))
+        );
+    }
+
+    private String generateMetricsMessage(Map<String, String> metrics) {
+        StringBuilder sb = new StringBuilder();
+
+        metrics.forEach((key, value) -> {
+            sb.append(key).append(" : ").append(value).append("\n");
+        });
+
+        return sb.toString();
+    }
+
+    private LayoutBlock getHeader(final String text) {
+        return Blocks.header(h -> h.text(
+                plainText(pt -> pt.emoji(true)
+                        .text(text))));
+    }
+
+    private LayoutBlock getSection(final String message) {
+        return Blocks.section(s ->
+                s.text(BlockCompositions.markdownText(message)));
+    }
+}

--- a/src/main/java/com/asap/server/persistence/repository/internal/MetricsRepository.java
+++ b/src/main/java/com/asap/server/persistence/repository/internal/MetricsRepository.java
@@ -1,0 +1,42 @@
+package com.asap.server.persistence.repository.internal;
+
+import static com.asap.server.persistence.domain.QMeeting.meeting;
+import static com.asap.server.persistence.domain.user.QUser.user;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MetricsRepository {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public Long countTotalMeetingCount(final LocalDateTime from, final LocalDateTime to) {
+        return jpaQueryFactory
+                .select(meeting.count())
+                .from(meeting)
+                .where(meeting.createdAt.between(from, to))
+                .fetchOne();
+    }
+
+    public Long countTotalConfirmedMeetingCount(final LocalDateTime from, final LocalDateTime to) {
+        return jpaQueryFactory
+                .select(meeting.count())
+                .from(meeting)
+                .where(
+                        meeting.confirmedDateTime.confirmedStartTime.isNotNull()
+                                .and(meeting.createdAt.between(from, to))
+                )
+                .fetchOne();
+    }
+
+    public Long countTotalUserCount(final LocalDateTime from, final LocalDateTime to) {
+        return jpaQueryFactory
+                .select(user.count())
+                .from(user)
+                .where(user.createdAt.between(from, to))
+                .fetchOne();
+    }
+}

--- a/src/main/java/com/asap/server/presentation/config/async/AsyncConfig.java
+++ b/src/main/java/com/asap/server/presentation/config/async/AsyncConfig.java
@@ -1,0 +1,20 @@
+package com.asap.server.presentation.config.async;
+
+import java.util.concurrent.Executor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+    @Bean
+    public Executor threadPoolTaskExecutor() {
+        ThreadPoolTaskExecutor taskExecutor = new ThreadPoolTaskExecutor();
+        taskExecutor.setCorePoolSize(1);
+        taskExecutor.setQueueCapacity(10);
+        taskExecutor.setMaxPoolSize(3);
+        return taskExecutor;
+    }
+}

--- a/src/main/java/com/asap/server/presentation/controller/internal/MetricsController.java
+++ b/src/main/java/com/asap/server/presentation/controller/internal/MetricsController.java
@@ -1,0 +1,27 @@
+package com.asap.server.presentation.controller.internal;
+
+import com.asap.server.common.exception.Success;
+import com.asap.server.presentation.common.dto.SuccessResponse;
+import com.asap.server.presentation.controller.internal.docs.MetricsControllerDocs;
+import com.asap.server.service.internal.MetricsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/internal")
+@RestController
+@RequiredArgsConstructor
+public class MetricsController implements MetricsControllerDocs {
+    private final MetricsService metricsService;
+
+    @GetMapping("/metrics")
+    public SuccessResponse sendMetrics(
+            @RequestParam("from") final String from,
+            @RequestParam("to") final String to
+    ) {
+        metricsService.sendMetrics(from.trim(), to.trim());
+        return SuccessResponse.success(Success.GET_METRICS_SUCCESS);
+    }
+}

--- a/src/main/java/com/asap/server/presentation/controller/internal/docs/MetricsControllerDocs.java
+++ b/src/main/java/com/asap/server/presentation/controller/internal/docs/MetricsControllerDocs.java
@@ -1,0 +1,29 @@
+package com.asap.server.presentation.controller.internal.docs;
+
+import com.asap.server.presentation.common.dto.ErrorResponse;
+import com.asap.server.presentation.common.dto.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "ASAP 내부 API", description = "ASAP 내부에서 사용하는 API입니다.")
+public interface MetricsControllerDocs {
+    @Operation(summary = "[메트릭 조회] ASAP에 등록된 메트릭 정보 조회 API")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "메트릭 정보 조회 성공입니다."),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "유효하지 않은 날짜를 입력했습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    SuccessResponse sendMetrics(
+            @Parameter(example = "2024-08-12", required = true) final String from,
+            @Parameter(example = "2024-08-15", required = true) final String to
+    );
+}

--- a/src/main/java/com/asap/server/service/internal/MetricsService.java
+++ b/src/main/java/com/asap/server/service/internal/MetricsService.java
@@ -1,0 +1,49 @@
+package com.asap.server.service.internal;
+
+import static com.asap.server.common.exception.Error.INVALID_DATE_FORMAT_EXCEPTION;
+
+import com.asap.server.common.exception.model.BadRequestException;
+import com.asap.server.infra.slack.MetricsEvent;
+import com.asap.server.persistence.repository.internal.MetricsRepository;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MetricsService {
+    private final MetricsRepository metricsRepository;
+    private final ApplicationEventPublisher publisher;
+
+    public void sendMetrics(final String fromStr, final String toStr) {
+        if (!isValidDate(fromStr) || !isValidDate(toStr)) {
+            throw new BadRequestException(INVALID_DATE_FORMAT_EXCEPTION);
+        }
+
+        LocalDateTime from = LocalDate.parse(fromStr, DateTimeFormatter.ISO_LOCAL_DATE).atStartOfDay();
+        LocalDateTime to = LocalDate.parse(toStr, DateTimeFormatter.ISO_LOCAL_DATE).atStartOfDay();
+
+        Map<String, String> metrics = new HashMap<>();
+        metrics.put("개설된 총 회의 수", String.valueOf(metricsRepository.countTotalMeetingCount(from, to)));
+        metrics.put("사용한 총 사용자 수", String.valueOf(metricsRepository.countTotalUserCount(from, to)));
+        metrics.put("확정된 총 회의 수", String.valueOf(metricsRepository.countTotalConfirmedMeetingCount(from, to)));
+
+        publisher.publishEvent(new MetricsEvent(metrics));
+    }
+
+    private boolean isValidDate(final String dateStr) {
+        try {
+            LocalDate.parse(dateStr, DateTimeFormatter.ISO_LOCAL_DATE);
+            return true;
+        } catch (DateTimeParseException e) {
+            return false;
+        }
+    }
+}

--- a/src/test/java/com/asap/server/service/internal/MetricsServiceTest.java
+++ b/src/test/java/com/asap/server/service/internal/MetricsServiceTest.java
@@ -1,0 +1,74 @@
+package com.asap.server.service.internal;
+
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.asap.server.common.exception.model.BadRequestException;
+import com.asap.server.infra.slack.MetricsEvent;
+import com.asap.server.persistence.repository.internal.MetricsRepository;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+@ExtendWith(MockitoExtension.class)
+class MetricsServiceTest {
+    @Mock
+    private MetricsRepository metricsRepository;
+    @Mock
+    private ApplicationEventPublisher publisher;
+    @InjectMocks
+    private MetricsService metricsService;
+
+    @DisplayName("날짜 형식은 yyyy-MM-dd 형식으로 입력한다.")
+    @Test
+    void test() {
+        // given
+        String fromStr = "2024-08-24";
+        String toStr = "2024-08-26";
+
+        LocalDateTime from = LocalDate.parse(fromStr, DateTimeFormatter.ISO_LOCAL_DATE).atStartOfDay();
+        LocalDateTime to = LocalDate.parse(toStr, DateTimeFormatter.ISO_LOCAL_DATE).atStartOfDay();
+
+        when(metricsRepository.countTotalMeetingCount(from, to)).thenReturn(1L);
+        when(metricsRepository.countTotalUserCount(from, to)).thenReturn(1L);
+        when(metricsRepository.countTotalConfirmedMeetingCount(from, to)).thenReturn(1L);
+        Map<String, String> metrics = Map.of(
+                "개설된 총 회의 수", "1",
+                "사용한 총 사용자 수", "1",
+                "확정된 총 회의 수", "1"
+        );
+
+        // when
+        metricsService.sendMetrics(fromStr, toStr);
+
+        // then
+        verify(publisher, times(1)).publishEvent(new MetricsEvent(metrics));
+    }
+
+    @DisplayName("날짜 형식(yyyy-MM-dd)과 다른 형식으로 입력했을 때, BadRequestException을 반환한다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"2024/08/24", "2024 08 24", "2024-13-24", "2024/08/32", "2024-13-30"})
+    void test2(String fromStr) {
+        // given
+        String toStr = "2024-08-26";
+
+        // when
+        assertThatThrownBy(() -> metricsService.sendMetrics(fromStr, toStr))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("유효하지 않은 날짜를 입력했습니다.");
+    }
+}


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #330 

## Key Changes 🔑
1. 내용
   - 명세대로 api 구현했습니다.
   - api 응답 속도 감소와 서비스와 slack 서비스의 의존성을 줄이고자 스프링 이벤트 방식을 사용했습니다.
   - 스프링 이벤트는 동기 방식으로 동작하기 때문에, 비동기 방식으로 동작하기 위해 `@Async` 어노테이션을 붙였고,
   `@Async` 어노테이션은 호출할 때마다 스레드를 생성하기 때문에, 별도의 스레드 풀을 만들었습니다.
   스레드 풀 같은 경우에는 이벤트 호출이 적을 것을 예상하여 스레드 풀을 1로 설정했습니다.

