### PR TITLE
#332 [feat] 메트릭 API 기간 입력 요구사항 반영

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,12 @@ bootJar {
     enabled = true;
 }
 
+tasks.test {
+    testLogging {
+        exceptionFormat = 'full'
+    }
+}
+
 configurations {
     compileOnly {
         extendsFrom annotationProcessor

--- a/src/main/java/com/asap/server/persistence/repository/internal/MetricsRepository.java
+++ b/src/main/java/com/asap/server/persistence/repository/internal/MetricsRepository.java
@@ -3,6 +3,8 @@ package com.asap.server.persistence.repository.internal;
 import static com.asap.server.persistence.domain.QMeeting.meeting;
 import static com.asap.server.persistence.domain.user.QUser.user;
 
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.DateTimePath;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
@@ -17,7 +19,7 @@ public class MetricsRepository {
         return jpaQueryFactory
                 .select(meeting.count())
                 .from(meeting)
-                .where(meeting.createdAt.between(from, to))
+                .where(generateDateFilter(meeting.createdAt, from, to))
                 .fetchOne();
     }
 
@@ -27,7 +29,7 @@ public class MetricsRepository {
                 .from(meeting)
                 .where(
                         meeting.confirmedDateTime.confirmedStartTime.isNotNull()
-                                .and(meeting.createdAt.between(from, to))
+                                .and(generateDateFilter(meeting.createdAt, from, to))
                 )
                 .fetchOne();
     }
@@ -36,7 +38,24 @@ public class MetricsRepository {
         return jpaQueryFactory
                 .select(user.count())
                 .from(user)
-                .where(user.createdAt.between(from, to))
+                .where(generateDateFilter(user.createdAt, from, to))
                 .fetchOne();
+    }
+
+    private BooleanExpression generateDateFilter(
+            final DateTimePath<LocalDateTime> createdAt,
+            final LocalDateTime from,
+            final LocalDateTime to
+    ) {
+        if (from != null && to != null) {
+            return createdAt.between(from, to);
+        }
+        if (from != null) {
+            return createdAt.after(from);
+        }
+        if (to != null) {
+            return createdAt.before(to);
+        }
+        return null;
     }
 }

--- a/src/main/java/com/asap/server/presentation/controller/internal/MetricsController.java
+++ b/src/main/java/com/asap/server/presentation/controller/internal/MetricsController.java
@@ -18,10 +18,10 @@ public class MetricsController implements MetricsControllerDocs {
 
     @GetMapping("/metrics")
     public SuccessResponse sendMetrics(
-            @RequestParam("from") final String from,
-            @RequestParam("to") final String to
+            @RequestParam(value = "from", required = false) final String from,
+            @RequestParam(value = "to", required = false) final String to
     ) {
-        metricsService.sendMetrics(from.trim(), to.trim());
+        metricsService.sendMetrics(from, to);
         return SuccessResponse.success(Success.GET_METRICS_SUCCESS);
     }
 }

--- a/src/main/java/com/asap/server/presentation/controller/internal/docs/MetricsControllerDocs.java
+++ b/src/main/java/com/asap/server/presentation/controller/internal/docs/MetricsControllerDocs.java
@@ -23,7 +23,7 @@ public interface MetricsControllerDocs {
             @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     SuccessResponse sendMetrics(
-            @Parameter(example = "2024-08-12", required = true) final String from,
-            @Parameter(example = "2024-08-15", required = true) final String to
+            @Parameter(example = "2024-08-12") final String from,
+            @Parameter(example = "2024-08-15") final String to
     );
 }

--- a/src/main/java/com/asap/server/service/internal/MetricsService.java
+++ b/src/main/java/com/asap/server/service/internal/MetricsService.java
@@ -5,7 +5,6 @@ import static com.asap.server.common.exception.Error.INVALID_DATE_FORMAT_EXCEPTI
 import com.asap.server.common.exception.model.BadRequestException;
 import com.asap.server.infra.slack.MetricsEvent;
 import com.asap.server.persistence.repository.internal.MetricsRepository;
-import java.io.IOException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -27,8 +26,14 @@ public class MetricsService {
             throw new BadRequestException(INVALID_DATE_FORMAT_EXCEPTION);
         }
 
-        LocalDateTime from = LocalDate.parse(fromStr, DateTimeFormatter.ISO_LOCAL_DATE).atStartOfDay();
-        LocalDateTime to = LocalDate.parse(toStr, DateTimeFormatter.ISO_LOCAL_DATE).atStartOfDay();
+        LocalDateTime from = null;
+        LocalDateTime to = null;
+        if (fromStr != null) {
+            from = LocalDate.parse(fromStr, DateTimeFormatter.ISO_LOCAL_DATE).atStartOfDay();
+        }
+        if (toStr != null) {
+            to = LocalDate.parse(toStr, DateTimeFormatter.ISO_LOCAL_DATE).atStartOfDay();
+        }
 
         Map<String, String> metrics = new HashMap<>();
         metrics.put("개설된 총 회의 수", String.valueOf(metricsRepository.countTotalMeetingCount(from, to)));
@@ -39,6 +44,10 @@ public class MetricsService {
     }
 
     private boolean isValidDate(final String dateStr) {
+        if (dateStr == null) {
+            return true;
+        }
+
         try {
             LocalDate.parse(dateStr, DateTimeFormatter.ISO_LOCAL_DATE);
             return true;

--- a/src/test/java/com/asap/server/concurrency/DuplicatedInterceptorTest.java
+++ b/src/test/java/com/asap/server/concurrency/DuplicatedInterceptorTest.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -27,6 +28,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@Transactional
 public class DuplicatedInterceptorTest {
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/com/asap/server/persistence/repository/internal/MetricsRepositoryGenerateDateFilterTest.java
+++ b/src/test/java/com/asap/server/persistence/repository/internal/MetricsRepositoryGenerateDateFilterTest.java
@@ -2,22 +2,17 @@ package com.asap.server.persistence.repository.internal;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-import com.asap.server.persistence.config.querydsl.QueryDslConfig;
 import jakarta.persistence.EntityManager;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
-@DataJpaTest
-@Import({QueryDslConfig.class, MetricsRepository.class})
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@SpringBootTest
 class MetricsRepositoryGenerateDateFilterTest {
     private static final String INSERT_QUERY_TEMPLATE = "INSERT INTO meeting (title, password, duration, place_type, additional_info, created_at) VALUES ('title', '1234', 'HALF','ONLINE', '', ?)";
 

--- a/src/test/java/com/asap/server/persistence/repository/internal/MetricsRepositoryGenerateDateFilterTest.java
+++ b/src/test/java/com/asap/server/persistence/repository/internal/MetricsRepositoryGenerateDateFilterTest.java
@@ -1,0 +1,112 @@
+package com.asap.server.persistence.repository.internal;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.asap.server.persistence.config.querydsl.QueryDslConfig;
+import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@DataJpaTest
+@Import({QueryDslConfig.class, MetricsRepository.class})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class MetricsRepositoryGenerateDateFilterTest {
+    private static final String INSERT_QUERY_TEMPLATE = "INSERT INTO meeting (title, password, duration, place_type, additional_info, created_at) VALUES ('title', '1234', 'HALF','ONLINE', '', ?)";
+
+    @Autowired
+    private MetricsRepository metricsRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    @DisplayName(
+            """
+                1. 2022년 5월 20일 데이터
+                2. 2023년 1월 1일 데이터
+                3. 2023년 6월 15일 데이터
+                4. 2023년 12월 31일 데이터
+            """
+    )
+    @BeforeEach
+    public void setUp() {
+        em.createNativeQuery(INSERT_QUERY_TEMPLATE)
+                .setParameter(1, "2022-05-20T10:00:00")
+                .executeUpdate();
+
+        em.createNativeQuery(INSERT_QUERY_TEMPLATE)
+                .setParameter(1, "2023-01-01T12:00:00")
+                .executeUpdate();
+
+        em.createNativeQuery(INSERT_QUERY_TEMPLATE)
+                .setParameter(1, "2023-06-15T15:30:00")
+                .executeUpdate();
+
+        em.createNativeQuery(INSERT_QUERY_TEMPLATE)
+                .setParameter(1, "2023-12-31T23:59:59")
+                .executeUpdate();
+    }
+
+    @DisplayName("시작 날짜와 종료 날짜 모두가 주어졌을 때, 주어진 범위 내의 결과를 반환한다.")
+    @Test
+    public void test() {
+        // given
+        LocalDateTime from = LocalDateTime.of(2023, 1, 1, 0, 0);
+        LocalDateTime to = LocalDateTime.of(2023, 12, 31, 0, 0);
+
+        // when
+        Long count = metricsRepository.countTotalMeetingCount(from, to);
+
+        // then
+        assertThat(count).isEqualTo(2);
+    }
+
+    @DisplayName("시작 날짜가 주어지고 종료 날짜가 주어지지 않았을 때, 시작 날짜 이후의 결과를 반환한다.")
+    @Test
+    public void test2() {
+        // given
+        LocalDateTime from = LocalDateTime.of(2023, 6, 1, 0, 0);
+        LocalDateTime to = null;
+
+        // when
+        Long count = metricsRepository.countTotalMeetingCount(from, to);
+
+        // then
+        assertThat(count).isEqualTo(2);
+    }
+
+    @DisplayName("종료 날짜가 주어지고 시작 날짜가 주어지지 않았을 때, 종료 날짜 이전의 결과를 반환한다.")
+    @Test
+    public void test3() {
+        // given
+        LocalDateTime from = null;
+        LocalDateTime to = LocalDateTime.of(2023, 1, 1, 0, 0);
+
+        // when
+        Long count = metricsRepository.countTotalMeetingCount(from, to);
+
+        // then
+        assertThat(count).isEqualTo(1);
+    }
+
+    @DisplayName("날짜 범위가 주어지지 않았을 때, 전범위를 반환한다.")
+    @Test
+    public void test4() {
+        // given
+        LocalDateTime from = null;
+        LocalDateTime to = null;
+
+        // when
+        Long count = metricsRepository.countTotalMeetingCount(from, to);
+
+        // then
+        assertThat(count).isEqualTo(4);
+    }
+}

--- a/src/test/java/com/asap/server/presentation/controller/MeetingRetrieveControllerTest.java
+++ b/src/test/java/com/asap/server/presentation/controller/MeetingRetrieveControllerTest.java
@@ -16,7 +16,9 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import java.nio.charset.Charset;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional
 @ExtendWith(MockitoExtension.class)
 public class MeetingRetrieveControllerTest {
 


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #332 

## Key Changes 🔑
1. 내용
   - 메트릭 API 요구사항 수정에 따라서 비즈니스 로직을 수정했습니다.
```
`/metrics` : 전체 데이터
`/metric?from=2024-08-01` : from 부터 현재까지 , created_at > from
`/metric?to=2024-08-01` :  to 까지 ,  created_at < to
`/metric?from=2024-08-04&to=2024-08-30` from에서 to까지 , from <= created_at <= to
```

위와 같이 요청해주시면 좋을 것 같습니다.

## To Reviewers 📢
- Querydsl의 DateTimePath을 이용해서 분기처리를 통일했습니다. 만약 from, to가 null이라면 조건문이 자동으로 들어가지 않습니다.
- 커밋 따라서 작업 내용 보시면 리뷰하시기 편하실 것이라 생각합니다~!
